### PR TITLE
OpenPOWER: Add support for OpenPOWER dump policy

### DIFF
--- a/dump-extensions/openpower-dumps/dump_manager_hardware.cpp
+++ b/dump-extensions/openpower-dumps/dump_manager_hardware.cpp
@@ -42,6 +42,9 @@ sdbusplus::message::object_path
             "Hardware dump accepts no additional parameters");
     }
 
+    // Check dump policy
+    util::isOPDumpsEnabled();
+
     uint32_t id = ++lastEntryId;
     // Entry Object path.
     auto objPath = std::filesystem::path(baseEntryPath) / std::to_string(id);

--- a/dump-extensions/openpower-dumps/dump_manager_hostboot.cpp
+++ b/dump-extensions/openpower-dumps/dump_manager_hostboot.cpp
@@ -42,6 +42,9 @@ sdbusplus::message::object_path
             "Hostboot dump accepts no additional parameters");
     }
 
+    // Check dump policy
+    util::isOPDumpsEnabled();
+
     uint32_t id = ++lastEntryId;
     // Entry Object path.
     auto objPath = std::filesystem::path(baseEntryPath) / std::to_string(id);

--- a/dump-extensions/openpower-dumps/dump_manager_resource.cpp
+++ b/dump-extensions/openpower-dumps/dump_manager_resource.cpp
@@ -3,6 +3,7 @@
 #include "dump_manager_resource.hpp"
 
 #include "dump_utils.hpp"
+#include "op_dump_util.hpp"
 #include "resource_dump_entry.hpp"
 #include "xyz/openbmc_project/Common/error.hpp"
 
@@ -75,10 +76,12 @@ void Manager::notify(uint32_t dumpId, uint64_t size)
 sdbusplus::message::object_path
     Manager::createDump(phosphor::dump::DumpCreateParams params)
 {
-
     using NotAllowed =
         sdbusplus::xyz::openbmc_project::Common::Error::NotAllowed;
     using Reason = xyz::openbmc_project::Common::NotAllowed::REASON;
+
+    // Check dump policy
+    util::isOPDumpsEnabled();
 
     // Allow creating resource dump only when the host is up.
     if (!phosphor::dump::isHostRunning())

--- a/dump-extensions/openpower-dumps/dump_manager_system.cpp
+++ b/dump-extensions/openpower-dumps/dump_manager_system.cpp
@@ -3,6 +3,7 @@
 #include "dump_manager_system.hpp"
 
 #include "dump_utils.hpp"
+#include "op_dump_util.hpp"
 #include "system_dump_entry.hpp"
 #include "xyz/openbmc_project/Common/error.hpp"
 
@@ -83,6 +84,9 @@ sdbusplus::message::object_path
     {
         log<level::WARNING>("System dump accepts no additional parameters");
     }
+
+    // Check dump policy
+    util::isOPDumpsEnabled();
 
     using NotAllowed =
         sdbusplus::xyz::openbmc_project::Common::Error::NotAllowed;

--- a/dump-extensions/openpower-dumps/op_dump_util.cpp
+++ b/dump-extensions/openpower-dumps/op_dump_util.cpp
@@ -1,8 +1,12 @@
 #include "op_dump_util.hpp"
 
+#include "xyz/openbmc_project/Common/error.hpp"
+#include "xyz/openbmc_project/Dump/Create/error.hpp"
+
 #include <fmt/core.h>
 #include <unistd.h>
 
+#include <phosphor-logging/elog-errors.hpp>
 #include <phosphor-logging/elog.hpp>
 
 #include <filesystem>
@@ -14,6 +18,8 @@ namespace dump
 namespace util
 {
 using namespace phosphor::logging;
+using InternalFailure =
+    sdbusplus::xyz::openbmc_project::Common::Error::InternalFailure;
 
 int callback(sd_event_source*, const siginfo_t*, void*)
 {
@@ -86,6 +92,47 @@ void captureDump(uint32_t dumpId, size_t allowedSize,
                 .c_str());
         throw std::runtime_error("Dump capture: Error occurred during fork");
     }
+}
+
+void isOPDumpsEnabled()
+{
+    bool enabled = true;
+    constexpr auto enable = "xyz.openbmc_project.Object.Enable";
+    constexpr auto policy = "/xyz/openbmc_project/dump/system_dump_policy";
+    constexpr auto property = "org.freedesktop.DBus.Properties";
+
+    using disabled =
+        sdbusplus::xyz::openbmc_project::Dump::Create::Error::Disabled;
+
+    try
+    {
+        auto bus = sdbusplus::bus::new_default();
+
+        auto service = phosphor::dump::getService(bus, policy, enable);
+
+        auto method =
+            bus.new_method_call(service.c_str(), policy, property, "Get");
+        method.append(enable, "Enabled");
+        auto reply = bus.call(method);
+        std::variant<bool> v;
+        reply.read(v);
+        enabled = std::get<bool>(v);
+    }
+    catch (const sdbusplus::exception::SdBusError& e)
+    {
+        log<level::ERR>(
+            fmt::format("Error({}) in getting dump policy, default is enabled",
+                        e.what())
+                .c_str());
+        report<InternalFailure>();
+    }
+
+    if (!enabled)
+    {
+        log<level::ERR>("OpePOWER dumps are disabled, skipping");
+        elog<disabled>();
+    }
+    log<level::INFO>("OpenPOWER dumps are enabled");
 }
 
 } // namespace util

--- a/dump-extensions/openpower-dumps/op_dump_util.hpp
+++ b/dump-extensions/openpower-dumps/op_dump_util.hpp
@@ -22,6 +22,15 @@ void captureDump(uint32_t dumpId, size_t allowedSize,
                  const std::string& dumpPrefix,
                  const phosphor::dump::EventPtr& event);
 
+/** @brief Check whether OpenPOWER dumps are enabled
+ *
+ * A xyz.openbmc_project.Dump.Create.Error.Disabled will be thrown
+ * if the dumps are disabled.
+ * If the settings service is not running then considering as
+ * the dumps are enabled.
+ */
+void isOPDumpsEnabled();
+
 } // namespace util
 } // namespace dump
 } // namespace openpower


### PR DESCRIPTION
Review link: https://gerrit.openbmc-project.xyz/c/openbmc/phosphor-debug-collector/+/46085

Add support for system dump policy, here system dump
refers to all OpenPOWER dumps, since all dumps from
host subsystems on OpenPOWER systems are known as system dumps.
The currently supported policy is dump enable. The dump will be
created only if the policy is enabled, if the dump is not
enabled, a dump disabled error will be returned.

If the settings service is not available, considering as
the dump is enabled.

Tests:
- Create a dump with policy enabled
busctl --verbose call xyz.openbmc_project.Settings /xyz/openbmc_project/dump/system_dump_policy org.freedesktop.DBus.Properties Get ss "xyz.openbmc_project.Object.Enable" "Enabled"
MESSAGE "v" {
        VARIANT "b" {
                BOOLEAN true;
        };
};

busctl --verbose call xyz.openbmc_project.Dump.Manager /xyz/openbmc_project/dump/resource  xyz.openbmc_project.Dump.Create CreateDump a{sv} 2 "com.ibm.Dump.Create.CreateParameters.VSPString" s "vsp" "com.ibm.Dump.Create.CreateParameters.Password" s "password"
MESSAGE "o" {
        OBJECT_PATH "/xyz/openbmc_project/dump/resource/entry/1";
};

Result: Dump created

- Create a dump with policy disabled
busctl --verbose call xyz.openbmc_project.Settings /xyz/openbmc_project/dump/system_dump_policy org.freedesktop.DBus.Properties Get ss "xyz.openbmc_project.Object.Enable" "Enabled"
MESSAGE "v" {
        VARIANT "b" {
                BOOLEAN false;
        };
};

busctl --verbose call xyz.openbmc_project.Dump.Manager /xyz/openbmc_project/dump/resource  xyz.openbmc_project.Dump.Create CreateDump a{sv} 2 "com.ibm.Dump.Create.CreateParameters.VSPString" s "vsp" "com.ibm.Dump.Create.CreateParameters.Password" s "password"
Call failed: Dump is disabled on this system.

Result: Dump is not allowed

Signed-off-by: Dhruvaraj Subhashchandran <dhruvaraj@in.ibm.com>
Change-Id: I5dc609b1f4fd0f36df8520f8a75c18a4cd3d7c4c