### PR TITLE
OpenPOWER: Add support for Self Boot Engine(SBE) dump

### DIFF
--- a/dump-extensions/openpower-dumps/dump-extensions.cpp
+++ b/dump-extensions/openpower-dumps/dump-extensions.cpp
@@ -7,6 +7,7 @@
 #include "dump_manager_hardware.hpp"
 #include "dump_manager_hostboot.hpp"
 #include "dump_manager_resource.hpp"
+#include "dump_manager_sbe.hpp"
 #include "dump_manager_system.hpp"
 #include "dump_utils.hpp"
 
@@ -62,6 +63,21 @@ void loadExtensions(sdbusplus::bus::bus& bus,
     dumpList.push_back(std::make_unique<openpower::dump::hardware::Manager>(
         bus, event, HARDWARE_DUMP_OBJPATH, HARDWARE_DUMP_OBJ_ENTRY,
         HARDWARE_DUMP_PATH));
+
+    try
+    {
+        std::filesystem::create_directories(SBE_DUMP_PATH);
+    }
+    catch (std::exception& e)
+    {
+        log<level::ERR>(fmt::format("Failed to create SBE dump directory({})",
+                                    SBE_DUMP_PATH)
+                            .c_str());
+        throw std::runtime_error("Failed to create SBE dump directory");
+    }
+
+    dumpList.push_back(std::make_unique<openpower::dump::sbe::Manager>(
+        bus, event, SBE_DUMP_OBJPATH, SBE_DUMP_OBJ_ENTRY, SBE_DUMP_PATH));
 }
 } // namespace dump
 } // namespace phosphor

--- a/dump-extensions/openpower-dumps/dump_manager_sbe.cpp
+++ b/dump-extensions/openpower-dumps/dump_manager_sbe.cpp
@@ -1,0 +1,108 @@
+#include "config.h"
+
+#include "dump_manager_sbe.hpp"
+
+#include "op_dump_util.hpp"
+#include "sbe_dump_entry.hpp"
+#include "xyz/openbmc_project/Common/error.hpp"
+#include "xyz/openbmc_project/Dump/Create/error.hpp"
+
+#include <fmt/core.h>
+#include <sys/inotify.h>
+#include <unistd.h>
+
+#include <phosphor-logging/elog-errors.hpp>
+#include <phosphor-logging/elog.hpp>
+
+#include <ctime>
+#include <regex>
+
+namespace openpower
+{
+namespace dump
+{
+namespace sbe
+{
+
+using namespace sdbusplus::xyz::openbmc_project::Common::Error;
+using namespace phosphor::logging;
+
+constexpr auto INVALID_DUMP_SIZE = 0;
+
+sdbusplus::message::object_path
+    Manager::createDump(phosphor::dump::DumpCreateParams params)
+{
+    if (!params.empty())
+    {
+        log<level::ERR>(fmt::format("SBE dump accepts no additional "
+                                    "parameters, number of parameters({})",
+                                    params.size())
+                            .c_str());
+        throw std::runtime_error("SBE dump accepts no additional parameters");
+    }
+
+    // Check dump policy
+    util::isOPDumpsEnabled();
+
+    uint32_t id = ++lastEntryId;
+    // Entry Object path.
+    auto objPath = std::filesystem::path(baseEntryPath) / std::to_string(id);
+
+    std::time_t timeStamp = std::time(nullptr);
+    createEntry(id, objPath, timeStamp, 0, std::string(),
+                phosphor::dump::OperationStatus::InProgress);
+
+    return objPath.string();
+}
+
+void Manager::createEntry(const uint32_t id, const std::string objPath,
+                          const uint64_t ms, uint64_t fileSize,
+                          const std::filesystem::path& file,
+                          phosphor::dump::OperationStatus status)
+{
+    try
+    {
+        entries.insert(
+            std::make_pair(id, std::make_unique<openpower::dump::sbe::Entry>(
+                                   bus, objPath.c_str(), id, ms, fileSize, file,
+                                   status, *this)));
+    }
+    catch (const std::invalid_argument& e)
+    {
+        log<level::ERR>(fmt::format("Error in creating SBE dump entry, "
+                                    "errormsg({}), OBJECTPATH({}), ID({}), "
+                                    "timestamp({}), filesize({}), status({})",
+                                    e.what(), objPath.c_str(), id, ms, fileSize,
+                                    status)
+                            .c_str());
+        throw std::runtime_error("Error in creating SBE dump entry");
+    }
+}
+
+void Manager::notify(uint32_t dumpId, uint64_t)
+{
+    // Get Dump size.
+    // TODO #ibm-openbmc/issues/3061
+    // Dump request will be rejected if there is not enough space told
+    // one complete dump, change this behavior to crate a partial dump
+    // with available space.
+    auto size = getAllowedSize();
+    std::vector<std::string> paths;
+    try
+    {
+        util::captureDump(dumpId, size, SBE_DUMP_TMP_FILE_DIR, dumpDir,
+                          "sbedump", eventLoop);
+    }
+    catch (std::exception& e)
+    {
+        log<level::ERR>(
+            fmt::format("Failed to package SBE dump: dump({id}) errorMsg({})",
+                        dumpId, e.what())
+                .c_str());
+        elog<InternalFailure>();
+    }
+}
+
+} // namespace sbe
+} // namespace dump
+} // namespace openpower

--- a/dump-extensions/openpower-dumps/dump_manager_sbe.hpp
+++ b/dump-extensions/openpower-dumps/dump_manager_sbe.hpp
@@ -1,0 +1,94 @@
+#pragma once
+
+#include "dump-extensions/openpower-dumps/openpower_dumps_config.h"
+
+#include "dump_manager_bmcstored.hpp"
+#include "dump_utils.hpp"
+#include "watch.hpp"
+#include "xyz/openbmc_project/Dump/NewDump/server.hpp"
+
+#include <com/ibm/Dump/Create/server.hpp>
+#include <xyz/openbmc_project/Dump/Create/server.hpp>
+
+#include <filesystem>
+
+namespace openpower
+{
+namespace dump
+{
+namespace sbe
+{
+
+constexpr auto SBE_DUMP_FILENAME_REGEX =
+    "hwdump_([0-9]+)_([0-9]+).([a-zA-Z0-9]+)";
+using CreateIface = sdbusplus::server::object::object<
+    sdbusplus::xyz::openbmc_project::Dump::server::Create,
+    sdbusplus::com::ibm::Dump::server::Create,
+    sdbusplus::xyz::openbmc_project::Dump::server::NewDump>;
+
+/** @class Manager
+ *  @brief SBE Dump  manager implementation.
+ *  @details A concrete implementation for the
+ *  xyz.openbmc_project.Dump.Create DBus API
+ */
+class Manager :
+    virtual public CreateIface,
+    virtual public phosphor::dump::bmc_stored::Manager
+{
+  public:
+    Manager() = delete;
+    Manager(const Manager&) = default;
+    Manager& operator=(const Manager&) = delete;
+    Manager(Manager&&) = delete;
+    Manager& operator=(Manager&&) = delete;
+    virtual ~Manager() = default;
+
+    /** @brief Constructor to put object onto bus at a dbus path.
+     *  @param[in] bus - Bus to attach to.
+     *  @param[in] event - Dump manager sd_event loop.
+     *  @param[in] path - Path to attach at.
+     *  @param[in] baseEntryPath - Base path for dump entry.
+     *  @param[in] filePath - Path where the dumps are stored.
+     */
+    Manager(sdbusplus::bus::bus& bus, const phosphor::dump::EventPtr& event,
+            const char* path, const std::string& baseEntryPath,
+            const char* filePath) :
+        CreateIface(bus, path),
+        phosphor::dump::bmc_stored::Manager(
+            bus, event, path, baseEntryPath, filePath, SBE_DUMP_FILENAME_REGEX,
+            SBE_DUMP_MAX_SIZE, SBE_DUMP_MIN_SPACE_REQD, SBE_DUMP_TOTAL_SIZE)
+    {}
+
+    /** @brief Implementation for CreateDump
+     *  Method to create a SBE dump entry when user requests for a
+     *  new SBE dump
+     *
+     *  @return object_path - The object path of the new dump entry.
+     */
+    sdbusplus::message::object_path
+        createDump(phosphor::dump::DumpCreateParams params) override;
+
+    /** @brief Notify the SBE dump manager about creation of a new dump.
+     *  @param[in] dumpId - Id from the source of the dump.
+     *  @param[in] size - Size of the dump.
+     */
+    void notify(uint32_t dumpId, uint64_t size) override;
+
+    /** @brief Create a  Dump Entry Object
+     *  @param[in] id - Id of the dump
+     *  @param[in] objPath - Object path to attach to
+     *  @param[in] ms - Dump creation timestamp
+     *             since the epoch.
+     *  @param[in] fileSize - Dump file size in bytes.
+     *  @param[in] file - Name of dump file.
+     *  @param[in] status - status of the dump.
+     */
+    void createEntry(const uint32_t id, const std::string objPath,
+                     const uint64_t ms, uint64_t fileSize,
+                     const std::filesystem::path& file,
+                     phosphor::dump::OperationStatus status) override;
+};
+
+} // namespace sbe
+} // namespace dump
+} // namespace openpower

--- a/dump-extensions/openpower-dumps/meson.build
+++ b/dump-extensions/openpower-dumps/meson.build
@@ -59,6 +59,28 @@ opconf_data.set('HARDWARE_DUMP_TOTAL_SIZE', get_option('HARDWARE_DUMP_TOTAL_SIZE
                description : 'Total size of the dump in kilo bytes'
             )
 
+opconf_data.set_quoted('SBE_DUMP_OBJPATH', get_option('SBE_DUMP_OBJPATH'),
+                      description : 'The SBE dump manager D-Bus path'
+                    )
+opconf_data.set_quoted('SBE_DUMP_OBJ_ENTRY', get_option('SBE_DUMP_OBJ_ENTRY'),
+                      description : 'The SBE dump entry D-Bus object path'
+                    )
+opconf_data.set_quoted('SBE_DUMP_TMP_FILE_DIR', get_option('SBE_DUMP_TMP_FILE_DIR'),
+                      description : 'Directory where hardwre dump pieces are stored for packaging'
+                    )
+opconf_data.set_quoted('SBE_DUMP_PATH', get_option('SBE_DUMP_PATH'),
+                     description : 'Directory where SBE dumps are placed'
+             )
+opconf_data.set('SBE_DUMP_MAX_SIZE', get_option('SBE_DUMP_MAX_SIZE'),
+               description : 'Maximum size of one SBE dump in kilo bytes'
+             )
+opconf_data.set('SBE_DUMP_MIN_SPACE_REQD', get_option('SBE_DUMP_MIN_SPACE_REQD'),
+               description : 'Minimum space required for one SBE dump in kilo bytes'
+             )
+opconf_data.set('SBE_DUMP_TOTAL_SIZE', get_option('SBE_DUMP_TOTAL_SIZE'),
+               description : 'Total size of the dump in kilo bytes'
+            )
+
 configure_file(configuration : opconf_data,
                output : 'openpower_dumps_config.h'
               )
@@ -72,4 +94,5 @@ phosphor_dump_manager_sources += [
         'dump-extensions/openpower-dumps/dump_manager_hostboot.cpp',
         'dump-extensions/openpower-dumps/op_dump_util.cpp',
         'dump-extensions/openpower-dumps/dump_manager_hardware.cpp',
+        'dump-extensions/openpower-dumps/dump_manager_sbe.cpp',
     ]

--- a/dump-extensions/openpower-dumps/sbe_dump_entry.hpp
+++ b/dump-extensions/openpower-dumps/sbe_dump_entry.hpp
@@ -1,0 +1,73 @@
+#pragma once
+
+#include "bmcstored_dump_entry.hpp"
+#include "com/ibm/Dump/Entry/SBE/server.hpp"
+#include "xyz/openbmc_project/Dump/Entry/server.hpp"
+#include "xyz/openbmc_project/Object/Delete/server.hpp"
+#include "xyz/openbmc_project/Time/EpochTime/server.hpp"
+
+#include <sdbusplus/bus.hpp>
+#include <sdbusplus/server/object.hpp>
+
+#include <filesystem>
+
+namespace openpower
+{
+namespace dump
+{
+namespace sbe
+{
+template <typename T>
+using ServerObject = typename sdbusplus::server::object::object<T>;
+
+using EntryIfaces = sdbusplus::server::object::object<
+    sdbusplus::com::ibm::Dump::Entry::server::SBE>;
+
+class Manager;
+
+/** @class Entry
+ *  @brief SBE Dump Entry implementation.
+ *  @details A concrete implementation for the
+ *  xyz.openbmc_project.Dump.Entry DBus API
+ */
+class Entry :
+    virtual public EntryIfaces,
+    virtual public phosphor::dump::bmc_stored::Entry
+{
+  public:
+    Entry() = delete;
+    Entry(const Entry&) = delete;
+    Entry& operator=(const Entry&) = delete;
+    Entry(Entry&&) = delete;
+    Entry& operator=(Entry&&) = delete;
+    ~Entry() = default;
+
+    /** @brief Constructor for the Dump Entry Object
+     *  @param[in] bus - Bus to attach to.
+     *  @param[in] objPath - Object path to attach to
+     *  @param[in] dumpId - Dump id.
+     *  @param[in] timeStamp - Dump creation timestamp
+     *             since the epoch.
+     *  @param[in] fileSize - Dump file size in bytes.
+     *  @param[in] file - Name of dump file.
+     *  @param[in] status - status of the dump.
+     *  @param[in] parent - The dump entry's parent.
+     */
+    Entry(sdbusplus::bus::bus& bus, const std::string& objPath, uint32_t dumpId,
+          uint64_t timeStamp, uint64_t fileSize,
+          const std::filesystem::path& file,
+          phosphor::dump::OperationStatus status,
+          phosphor::dump::Manager& parent) :
+        EntryIfaces(bus, objPath.c_str(), true),
+        phosphor::dump::bmc_stored::Entry(bus, objPath.c_str(), dumpId,
+                                          timeStamp, fileSize, file, status,
+                                          parent)
+    {
+        // Emit deferred signal.
+        this->openpower::dump::sbe::EntryIfaces::emit_object_added();
+    }
+};
+
+} // namespace sbe
+} // namespace dump
+} // namespace openpower

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -220,3 +220,40 @@ option('HARDWARE_DUMP_TOTAL_SIZE', type : 'integer',
         value : 409600,
         description : 'Total size of the hardware dump in kilo bytes'
       )
+
+# SBE dump options
+
+option('SBE_DUMP_OBJPATH', type : 'string',
+        value : '/xyz/openbmc_project/dump/sbe',
+        description : 'The SBE dump manager D-Bus object path'
+      )
+
+option('SBE_DUMP_OBJ_ENTRY', type : 'string',
+        value : '/xyz/openbmc_project/dump/sbe/entry',
+        description : 'The SBE dump entry D-Bus object path'
+      )
+
+option('SBE_DUMP_TMP_FILE_DIR', type : 'string',
+        value : '/tmp/openpower-dumps/sbe',
+        description : 'Directory where SBE dump pieces are stored for packaging'
+      )
+
+option('SBE_DUMP_PATH', type : 'string',
+        value : '/var/lib/phosphor-debug-collector/sbedump/',
+        description : 'Directory where SBE dumps are placed'
+      )
+
+option('SBE_DUMP_MAX_SIZE', type : 'integer',
+        value : 102400,
+        description : 'Maximum size of one SBE dump in kilo bytes'
+      )
+
+option('SBE_DUMP_MIN_SPACE_REQD', type : 'integer',
+        value : 81920,
+        description : 'Minimum space required for one SBE dump in kilo bytes'
+      )
+
+option('SBE_DUMP_TOTAL_SIZE', type : 'integer',
+        value : 409600,
+        description : 'Total size of the SBE dump in kilo bytes'
+      )


### PR DESCRIPTION
gerrit link: https://gerrit.openbmc-project.xyz/c/openbmc/phosphor-debug-collector/+/47037/3
Self Boot Engine(SBE) is a microcontroller that sits inside the processor
to initialize it to start the booting and also acts as a secure channel
for accessing certain control functions on the processor. During the
booting or other hardware access operations SBE can encounter errors
and become unresponsive. In such situations, the debug data needs to be
collected from such SBEs to find out the root cause of the error.
This data includes hardware state, configuration, memory, etc.
The collected data is then packaged into the OpenPOWER dump format
and which is called as SBE dump.

This commit adds implementation for SBE dump entry creation,
package, list, deletion, and offload.

Tests:
Create entry
List entry
Delete entry

Signed-off-by: Dhruvaraj Subhashchandran <dhruvaraj@in.ibm.com>
Change-Id: Iaaac90a83d68b51a0076bfe3c7d254b978b60309