### PR TITLE
Implement InitiatedBy interface in dump entry dbus obj

### DIFF
--- a/dump_entry.hpp
+++ b/dump_entry.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "com/ibm/Dump/InitiatedBy/server.hpp"
 #include "xyz/openbmc_project/Common/Progress/server.hpp"
 #include "xyz/openbmc_project/Dump/Entry/server.hpp"
 #include "xyz/openbmc_project/Object/Delete/server.hpp"
@@ -26,7 +27,8 @@ using EntryIfaces = sdbusplus::server::object::object<
     sdbusplus::xyz::openbmc_project::Common::server::Progress,
     sdbusplus::xyz::openbmc_project::Dump::server::Entry,
     sdbusplus::xyz::openbmc_project::Object::server::Delete,
-    sdbusplus::xyz::openbmc_project::Time::server::EpochTime>;
+    sdbusplus::xyz::openbmc_project::Time::server::EpochTime,
+    sdbusplus::com::ibm::Dump::server::InitiatedBy>;
 
 using OperationStatus =
     sdbusplus::xyz::openbmc_project::Common::server::Progress::OperationStatus;
@@ -95,6 +97,16 @@ class Entry : public EntryIfaces
     void initiateOffload(std::string uri) override
     {
         offloadUri(uri);
+    }
+
+    /** @brief Method to set the session id which
+     *         indicates the session that
+     *         initiates the dump
+     *  @param[in] sessionId - session id of the client
+     */
+    void setSessionId(std::string sessionId)
+    {
+        sessionId = sessionId;
     }
 
   protected:


### PR DESCRIPTION
This new interface "InitiatedBy" will be implemented
by all the dump entry dbus objects. It contains a
property "SessionId" which stores the session id that
has initiated the dump collection.

The dbus interface change for the same is at:
https://gerrit.openbmc-project.xyz/c/openbmc/phosphor-dbus-interfaces/+/47057

The design document is at:
https://gerrit.openbmc-project.xyz/c/openbmc/docs/+/47446

Signed-off-by: Asmitha Karunanithi <asmitk01@in.ibm.com>
Change-Id: If5eaadb8b1d879f4c22b28bba62e4a79d15c5d5a