### PR TITLE
Implement GeneratedBy interface in dump entry dbus obj

### DIFF
--- a/bmc_dump_entry.hpp
+++ b/bmc_dump_entry.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "bmcstored_dump_entry.hpp"
+#include "xyz/openbmc_project/Common/GeneratedBy/server.hpp"
 #include "xyz/openbmc_project/Dump/Entry/BMC/server.hpp"
 
 #include <sdbusplus/bus.hpp>
@@ -18,6 +19,7 @@ template <typename T>
 using ServerObject = typename sdbusplus::server::object::object<T>;
 
 using EntryIfaces = sdbusplus::server::object::object<
+    sdbusplus::xyz::openbmc_project::Common::server::GeneratedBy,
     sdbusplus::xyz::openbmc_project::Dump::Entry::server::BMC>;
 
 class Manager;
@@ -52,7 +54,7 @@ class Entry :
      */
     Entry(sdbusplus::bus::bus& bus, const std::string& objPath, uint32_t dumpId,
           uint64_t timeStamp, uint64_t fileSize,
-          const std::filesystem::path& file,
+          const std::filesystem::path& file, std::string genId,
           phosphor::dump::OperationStatus status,
           phosphor::dump::Manager& parent) :
         EntryIfaces(bus, objPath.c_str(), true),
@@ -60,6 +62,7 @@ class Entry :
                                           timeStamp, fileSize, file, status,
                                           parent)
     {
+        generatorId(genId);
         // Emit deferred signal.
         this->phosphor::dump::bmc::EntryIfaces::emit_object_added();
     }

--- a/dump-extensions/openpower-dumps/dump_manager_resource.cpp
+++ b/dump-extensions/openpower-dumps/dump_manager_resource.cpp
@@ -51,12 +51,15 @@ void Manager::notify(uint32_t dumpId, uint64_t size)
     auto idString = std::to_string(id);
     auto objPath = std::filesystem::path(baseEntryPath) / idString;
 
+    // TODO: Get the generator Id from the persisted file.
+    // For now replacing it with null
+
     try
     {
         entries.insert(std::make_pair(
             id, std::make_unique<resource::Entry>(
                     bus, objPath.c_str(), id, timeStamp, size, dumpId,
-                    std::string(), std::string(),
+                    std::string(), std::string(), std::string(),
                     phosphor::dump::OperationStatus::Completed, *this)));
     }
     catch (const std::invalid_argument& e)
@@ -96,6 +99,8 @@ sdbusplus::message::object_path
     using Argument = xyz::openbmc_project::Common::InvalidArgument;
     using CreateParameters =
         sdbusplus::com::ibm::Dump::server::Create::CreateParameters;
+    using CreateParametersXYZ =
+        sdbusplus::xyz::openbmc_project::Dump::server::Create::CreateParameters;
 
     auto id = lastEntryId + 1;
     auto idString = std::to_string(id);
@@ -154,13 +159,39 @@ sdbusplus::message::object_path
                               Argument::ARGUMENT_VALUE("INVALID INPUT"));
     }
 
+    std::string generatorId;
+    iter = params.find(
+        sdbusplus::xyz::openbmc_project::Dump::server::Create::
+            convertCreateParametersToString(CreateParametersXYZ::GeneratorId));
+    if (iter == params.end())
+    {
+        log<level::INFO>(
+            "GeneratorId is not provided. Replacing the string with null");
+    }
+    else
+    {
+        try
+        {
+            generatorId = std::get<std::string>(iter->second);
+        }
+        catch (const std::bad_variant_access& e)
+        {
+            // Exception will be raised if the input is not string
+            log<level::ERR>(
+                "An invalid  generatorId passed. It should be a string",
+                entry("ERROR_MSG=%s", e.what()));
+            elog<InvalidArgument>(Argument::ARGUMENT_NAME("GENERATOR_ID"),
+                                  Argument::ARGUMENT_VALUE("INVALID INPUT"));
+        }
+    }
+
     try
     {
         entries.insert(std::make_pair(
             id, std::make_unique<resource::Entry>(
                     bus, objPath.c_str(), id, timeStamp, 0, INVALID_SOURCE_ID,
-                    vspString, pwd, phosphor::dump::OperationStatus::InProgress,
-                    *this)));
+                    vspString, pwd, generatorId,
+                    phosphor::dump::OperationStatus::InProgress, *this)));
     }
     catch (const std::invalid_argument& e)
     {

--- a/dump-extensions/openpower-dumps/dump_manager_system.cpp
+++ b/dump-extensions/openpower-dumps/dump_manager_system.cpp
@@ -50,12 +50,15 @@ void Manager::notify(uint32_t dumpId, uint64_t size)
     auto idString = std::to_string(id);
     auto objPath = std::filesystem::path(baseEntryPath) / idString;
 
+    // TODO: Get the generator Id from the persisted file.
+    // For now replacing it with null
     try
     {
         entries.insert(std::make_pair(
             id, std::make_unique<system::Entry>(
                     bus, objPath.c_str(), id, timeStamp, size, dumpId,
-                    phosphor::dump::OperationStatus::Completed, *this)));
+                    std::string(), phosphor::dump::OperationStatus::Completed,
+                    *this)));
     }
     catch (const std::invalid_argument& e)
     {
@@ -80,9 +83,10 @@ sdbusplus::message::object_path
     constexpr auto SYSTEMD_INTERFACE = "org.freedesktop.systemd1.Manager";
     constexpr auto DIAG_MOD_TARGET = "obmc-host-crash@0.target";
 
-    if (!params.empty())
+    if (params.size() > 1)
     {
-        log<level::WARNING>("System dump accepts no additional parameters");
+        log<level::WARNING>(
+            "System dump accepts not more than 1 additional parameter");
     }
 
     // Check dump policy
@@ -98,6 +102,39 @@ sdbusplus::message::object_path
         elog<NotAllowed>(
             Reason("System dump can be initiated only when the host is up"));
         return std::string();
+    }
+
+    // Get the generator id from params
+    using InvalidArgument =
+        sdbusplus::xyz::openbmc_project::Common::Error::InvalidArgument;
+    using Argument = xyz::openbmc_project::Common::InvalidArgument;
+    using CreateParameters =
+        sdbusplus::xyz::openbmc_project::Dump::server::Create::CreateParameters;
+
+    std::string generatorId;
+    auto iter = params.find(
+        sdbusplus::xyz::openbmc_project::Dump::server::Create::
+            convertCreateParametersToString(CreateParameters::GeneratorId));
+    if (iter == params.end())
+    {
+        log<level::INFO>(
+            "GeneratorId is not provided. Replacing the string with null");
+    }
+    else
+    {
+        try
+        {
+            generatorId = std::get<std::string>(iter->second);
+        }
+        catch (const std::bad_variant_access& e)
+        {
+            // Exception will be raised if the input is not string
+            log<level::ERR>(
+                "An invalid  generatorId passed. It should be a string",
+                entry("ERROR_MSG=%s", e.what()));
+            elog<InvalidArgument>(Argument::ARGUMENT_NAME("GENERATOR_ID"),
+                                  Argument::ARGUMENT_VALUE("INVALID INPUT"));
+        }
     }
 
     auto b = sdbusplus::bus::new_default();
@@ -117,7 +154,8 @@ sdbusplus::message::object_path
         entries.insert(std::make_pair(
             id, std::make_unique<system::Entry>(
                     bus, objPath.c_str(), id, timeStamp, 0, INVALID_SOURCE_ID,
-                    phosphor::dump::OperationStatus::InProgress, *this)));
+                    generatorId, phosphor::dump::OperationStatus::InProgress,
+                    *this)));
     }
     catch (const std::invalid_argument& e)
     {

--- a/dump-extensions/openpower-dumps/resource_dump_entry.hpp
+++ b/dump-extensions/openpower-dumps/resource_dump_entry.hpp
@@ -2,6 +2,7 @@
 
 #include "com/ibm/Dump/Entry/Resource/server.hpp"
 #include "dump_entry.hpp"
+#include "xyz/openbmc_project/Common/GeneratedBy/server.hpp"
 
 #include <sdbusplus/bus.hpp>
 #include <sdbusplus/server/object.hpp>
@@ -18,6 +19,7 @@ template <typename T>
 using ServerObject = typename sdbusplus::server::object::object<T>;
 
 using EntryIfaces = sdbusplus::server::object::object<
+    sdbusplus::xyz::openbmc_project::Common::server::GeneratedBy,
     sdbusplus::com::ibm::Dump::Entry::server::Resource>;
 
 class Manager;
@@ -53,7 +55,7 @@ class Entry : virtual public EntryIfaces, virtual public phosphor::dump::Entry
      */
     Entry(sdbusplus::bus::bus& bus, const std::string& objPath, uint32_t dumpId,
           uint64_t timeStamp, uint64_t dumpSize, const uint32_t sourceId,
-          std::string vspStr, std::string pwd,
+          std::string vspStr, std::string pwd, std::string genId,
           phosphor::dump::OperationStatus status,
           phosphor::dump::Manager& parent) :
         EntryIfaces(bus, objPath.c_str(), true),
@@ -63,6 +65,7 @@ class Entry : virtual public EntryIfaces, virtual public phosphor::dump::Entry
         sourceDumpId(sourceId);
         vspString(vspStr);
         password(pwd);
+        generatorId(genId);
         // Emit deferred signal.
         this->openpower::dump::resource::EntryIfaces::emit_object_added();
     };

--- a/dump-extensions/openpower-dumps/system_dump_entry.hpp
+++ b/dump-extensions/openpower-dumps/system_dump_entry.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "dump_entry.hpp"
+#include "xyz/openbmc_project/Common/GeneratedBy/server.hpp"
 #include "xyz/openbmc_project/Dump/Entry/System/server.hpp"
 
 #include <sdbusplus/bus.hpp>
@@ -16,6 +17,7 @@ template <typename T>
 using ServerObject = typename sdbusplus::server::object::object<T>;
 
 using EntryIfaces = sdbusplus::server::object::object<
+    sdbusplus::xyz::openbmc_project::Common::server::GeneratedBy,
     sdbusplus::xyz::openbmc_project::Dump::Entry::server::System>;
 
 class Manager;
@@ -48,13 +50,14 @@ class Entry : virtual public EntryIfaces, virtual public phosphor::dump::Entry
      */
     Entry(sdbusplus::bus::bus& bus, const std::string& objPath, uint32_t dumpId,
           uint64_t timeStamp, uint64_t dumpSize, const uint32_t sourceId,
-          phosphor::dump::OperationStatus status,
+          std::string genId, phosphor::dump::OperationStatus status,
           phosphor::dump::Manager& parent) :
         EntryIfaces(bus, objPath.c_str(), true),
         phosphor::dump::Entry(bus, objPath.c_str(), dumpId, timeStamp, dumpSize,
                               status, parent)
     {
         sourceDumpId(sourceId);
+        generatorId(genId);
         // Emit deferred signal.
         this->openpower::dump::system::EntryIfaces::emit_object_added();
     };

--- a/dump_manager_bmc.cpp
+++ b/dump_manager_bmc.cpp
@@ -40,10 +40,45 @@ void Manager::create(Type type, std::vector<std::string> fullPaths)
 sdbusplus::message::object_path
     Manager::createDump(phosphor::dump::DumpCreateParams params)
 {
-    if (!params.empty())
+    if (params.size() > 1)
     {
-        log<level::WARNING>("BMC dump accepts no additional parameters");
+        log<level::WARNING>(
+            "BMC dump accepts not more than 1 additional parameter");
     }
+
+    // Get the generator id from params
+    using InvalidArgument =
+        sdbusplus::xyz::openbmc_project::Common::Error::InvalidArgument;
+    using Argument = xyz::openbmc_project::Common::InvalidArgument;
+    using CreateParameters =
+        sdbusplus::xyz::openbmc_project::Dump::server::Create::CreateParameters;
+
+    std::string generatorId;
+    auto iter = params.find(
+        sdbusplus::xyz::openbmc_project::Dump::server::Create::
+            convertCreateParametersToString(CreateParameters::GeneratorId));
+    if (iter == params.end())
+    {
+        log<level::INFO>(
+            "GeneratorId is not provided. Replacing the string with null");
+    }
+    else
+    {
+        try
+        {
+            generatorId = std::get<std::string>(iter->second);
+        }
+        catch (const std::bad_variant_access& e)
+        {
+            // Exception will be raised if the input is not string
+            log<level::ERR>(
+                "An invalid  generatorId passed. It should be a string",
+                entry("ERROR_MSG=%s", e.what()));
+            elog<InvalidArgument>(Argument::ARGUMENT_NAME("GENERATOR_ID"),
+                                  Argument::ARGUMENT_VALUE("INVALID INPUT"));
+        }
+    }
+
     std::vector<std::string> paths;
     auto id = captureDump(Type::UserRequested, paths);
 
@@ -51,7 +86,8 @@ sdbusplus::message::object_path
     auto objPath = std::filesystem::path(baseEntryPath) / std::to_string(id);
 
     std::time_t timeStamp = std::time(nullptr);
-    createEntry(id, objPath, timeStamp, 0, std::string(),
+
+    createEntry(id, objPath, timeStamp, 0, std::string(), generatorId,
                 phosphor::dump::OperationStatus::InProgress);
     return objPath.string();
 }
@@ -59,6 +95,7 @@ sdbusplus::message::object_path
 void Manager::createEntry(const uint32_t id, const std::string objPath,
                           const uint64_t ms, uint64_t fileSize,
                           const std::filesystem::path& file,
+                          const std::string& generatorId,
                           phosphor::dump::OperationStatus status)
 {
     try
@@ -66,7 +103,7 @@ void Manager::createEntry(const uint32_t id, const std::string objPath,
         entries.insert(
             std::make_pair(id, std::make_unique<phosphor::dump::bmc::Entry>(
                                    bus, objPath.c_str(), id, ms, fileSize, file,
-                                   status, *this)));
+                                   generatorId, status, *this)));
     }
     catch (const std::invalid_argument& e)
     {
@@ -76,6 +113,14 @@ void Manager::createEntry(const uint32_t id, const std::string objPath,
                             .c_str());
         elog<InternalFailure>();
     }
+}
+
+void Manager::createEntry(const uint32_t id, const std::string objPath,
+                          const uint64_t ms, uint64_t fileSize,
+                          const std::filesystem::path& file,
+                          phosphor::dump::OperationStatus status)
+{
+    createEntry(id, objPath, ms, fileSize, file, "", status);
 }
 
 uint32_t Manager::captureDump(Type type,

--- a/dump_manager_bmc.hpp
+++ b/dump_manager_bmc.hpp
@@ -87,6 +87,23 @@ class Manager :
      *             since the epoch.
      *  @param[in] fileSize - Dump file size in bytes.
      *  @param[in] file - Name of dump file.
+     *  @param[in] generatorId - id of the user initiated the dump.
+     *  @param[in] status - status of the dump.
+     *  @param[in] parent - The dump entry's parent.
+     */
+    void createEntry(const uint32_t id, const std::string objPath,
+                     const uint64_t ms, uint64_t fileSize,
+                     const std::filesystem::path& file,
+                     const std::string& generatorId,
+                     phosphor::dump::OperationStatus status);
+
+    /** @brief Create a  Dump Entry Object
+     *  @param[in] id - Id of the dump
+     *  @param[in] objPath - Object path to attach to
+     *  @param[in] timeStamp - Dump creation timestamp
+     *             since the epoch.
+     *  @param[in] fileSize - Dump file size in bytes.
+     *  @param[in] file - Name of dump file.
      *  @param[in] status - status of the dump.
      *  @param[in] parent - The dump entry's parent.
      */


### PR DESCRIPTION
This new interface "GeneratedBy" will be implemented
by all the dump entry dbus objects that can be user-
initiated. It contains a property "GeneratorId" which
stores the unique id of the user that has initiated
the dump.

The dbus interface change for the same is at:
https://github.com/ibm-openbmc/phosphor-dbus-interfaces/pull/26/

The design document is at:
https://gerrit.openbmc-project.xyz/c/openbmc/docs/+/47446/

The gerrit change is at:
https://gerrit.openbmc-project.xyz/c/openbmc/phosphor-debug-collector/+/48337

Tested By:

1.  busctl call xyz.openbmc_project.Dump.Manager /xyz/openbmc_project/dump/bmc xyz.openbmc_project.Dump.Create CreateDump a{sv} 1 "xyz.openbmc_project.Dump.Create.CreateParameters.GeneratorId" s "9iu0ojsx"
o "/xyz/openbmc_project/dump/bmc/entry/2"

* busctl introspect xyz.openbmc_project.Dump.Manager /xyz/openbmc_project/dump/bmc/entry/2NAME                                   TYPE      SIGNATURE RESULT/VALUE                             FLAGS
org.freedesktop.DBus.Introspectable    interface -         -                                        -
.Introspect                            method    -         s                                        -
org.freedesktop.DBus.Peer              interface -         -                                        -
.GetMachineId                          method    -         s                                        -
.Ping                                  method    -         -                                        -
org.freedesktop.DBus.Properties        interface -         -                                        -
.Get                                   method    ss        v                                        -
.GetAll                                method    s         a{sv}                                    -
.Set                                   method    ssv       -                                        -
.PropertiesChanged                     signal    sa{sv}as  -                                        -
xyz.openbmc_project.Common.GeneratedBy interface -         -                                        -
.GeneratorId                           property  s         "9iu0ojsx"                               emits-change writable
xyz.openbmc_project.Common.Progress    interface -         -                                        -
.CompletedTime                         property  t         0                                        emits-change writable
.StartTime                             property  t         1634724632                               emits-change writable
.Status                                property  s         "xyz.openbmc_project.Common.Progress.Op… emits-change writable
xyz.openbmc_project.Dump.Entry         interface -         -                                        -
.InitiateOffload                       method    s         -                                        -
.OffloadUri                            property  s         ""                                       emits-change writable
.Offloaded                             property  b         false                                    emits-change writable
.Size                                  property  t         0                                        emits-change writable
xyz.openbmc_project.Dump.Entry.BMC     interface -         -                                        -
xyz.openbmc_project.Object.Delete      interface -         -                                        -
.Delete                                method    -         -                                        -
xyz.openbmc_project.Time.EpochTime     interface -         -                                        -
.Elapsed                               property  t         0                                        emits-change writable

2. busctl --verbose call xyz.openbmc_project.Dump.Manager /xyz/openbmc_project/dump/resource  xyz.openbmc_project.Dump.Create CreateDump a{sv} 3 "com.ibm.Dump.Create.CreateParameters.VSPString" s "vsp" "com.ibm.Dump.Create.CreateParameters.Password" s "password" "xyz.openbmc_project.Dump.Create.CreateParameters.GeneratorId" s "9iu0ojsx"MESSAGE "o" {
        OBJECT_PATH "/xyz/openbmc_project/dump/resource/entry/1";
};

3. busctl call xyz.openbmc_project.Dump.Manager /xyz/openbmc_project/dump/system xyz.openbmc_project.Dump.Create CreateDump a{sv} 1 "xyz.openbmc_project.Dump.Create.CreateParameters.GeneratorId" s "9iu0ojsx"
o "/xyz/openbmc_project/dump/system/entry/1"

Signed-off-by: Asmitha Karunanithi <asmitk01@in.ibm.com>
Change-Id: I13f1b2429e373d83015c6920c3bd1c82c3de1b88