### PR TITLE
opdreport: Adding different ids based on dump type

### DIFF
--- a/dump-extensions/openpower-dumps/opdreport
+++ b/dump-extensions/openpower-dumps/opdreport
@@ -31,6 +31,8 @@ Options:
 #CONSTANTS
 declare -rx TYPE_OPDUMP="opdump"
 declare -rx DREPORT_SOURCE="/usr/share/dreport.d"
+declare -rx HBDUMP_ID="20000000"
+declare -rx SBEDUMP_ID="30000000"
 
 #VARIABLES
 declare -x EPOCHTIME
@@ -58,6 +60,11 @@ function initialize()
         echo "Error: Name of the dump is not provided."
         return "$RESOURCE_UNAVAILABLE";
     else
+        if [ "$name" = "hbdump" ]; then
+            dump_id=$((HBDUMP_ID + dump_id))
+        elif [ "$name" = "sbedump" ]; then
+            dump_id=$((SBEDUMP_ID + dump_id))
+        fi
         name="${name}_${dump_id}_${EPOCHTIME}"
     fi
 


### PR DESCRIPTION
Change:
-Adding different ids to dumps like sbe and hbdump, so that
user can identify the dump type by looking at ids.
Confusion was, once dumps get offloaded the name changes to
SYSDUMP_1_<TIME>.gz so it was hard to distinguish the dump
type.

Tested:
-Post changes can see, sbe and hbdump are getting different dump
ids.
Previous dump ids were:
hbdump_1_1638868121.gz and sbedump_1_1638868193.gz

Examples below post change:
hbdump_20000001_1638868121.gz and sbedump_30000001_1638868193.gz

Signed-off-by: Chirag Sharma <chirshar@in.ibm.com>