### PR TITLE
opdreport: Adding dump creator in header

### DIFF
--- a/tools/dreport.d/ibm.d/gendumpheader
+++ b/tools/dreport.d/ibm.d/gendumpheader
@@ -434,7 +434,8 @@ function mainstore_dump_section () {
 #hardwareCollectionStartTime  8
 #mdstTableSize           4
 #payloadState            4
-#reservedForCreator      170
+#creator BMC             1
+#reservedForCreator      169
 function plat_dump_header () {
     printf "SYS DUMP" >> "$FILE"
     dump_time
@@ -452,7 +453,9 @@ function plat_dump_header () {
     get_eid
     add_null 500
     content_type # 4 bytes
-    add_null 412
+    add_null 44
+    printf '\x01' >> "$FILE"  # BMC indicator
+    add_null 367
 }
 
 


### PR DESCRIPTION
Change:
-Adding dump creator id i.e. 0x01 for BMC dump,
it is required to know the dump was created on
BMC platform.

Tested:
-Can see the byte getting reflected in header.

Signed-off-by: Chirag Sharma <chirshar@in.ibm.com>