### PR TITLE
Update host dump ids

### DIFF
--- a/dump-extensions/openpower-dumps/dump-extensions.cpp
+++ b/dump-extensions/openpower-dumps/dump-extensions.cpp
@@ -46,9 +46,9 @@ void loadExtensions(sdbusplus::bus::bus& bus,
     dumpList.push_back(std::make_unique<openpower::dump::hostdump::Manager<
                            openpower::dump::hostboot::Entry>>(
         bus, event, HOSTBOOT_DUMP_OBJPATH, HOSTBOOT_DUMP_OBJ_ENTRY,
-        HOSTBOOT_DUMP_PATH, "hbdump", HOSTBOOT_DUMP_TMP_FILE_DIR,
-        HOSTBOOT_DUMP_MAX_SIZE, HOSTBOOT_DUMP_MIN_SPACE_REQD,
-        HOSTBOOT_DUMP_TOTAL_SIZE));
+        HOSTBOOT_DUMP_START_ID, HOSTBOOT_DUMP_PATH, "hbdump",
+        HOSTBOOT_DUMP_TMP_FILE_DIR, HOSTBOOT_DUMP_MAX_SIZE,
+        HOSTBOOT_DUMP_MIN_SPACE_REQD, HOSTBOOT_DUMP_TOTAL_SIZE));
 
     try
     {
@@ -66,9 +66,9 @@ void loadExtensions(sdbusplus::bus::bus& bus,
     dumpList.push_back(std::make_unique<openpower::dump::hostdump::Manager<
                            openpower::dump::hardware::Entry>>(
         bus, event, HARDWARE_DUMP_OBJPATH, HARDWARE_DUMP_OBJ_ENTRY,
-        HARDWARE_DUMP_PATH, "hwdump", HARDWARE_DUMP_TMP_FILE_DIR,
-        HARDWARE_DUMP_MAX_SIZE, HARDWARE_DUMP_MIN_SPACE_REQD,
-        HARDWARE_DUMP_TOTAL_SIZE));
+        HARDWARE_DUMP_START_ID, HARDWARE_DUMP_PATH, "hwdump",
+        HARDWARE_DUMP_TMP_FILE_DIR, HARDWARE_DUMP_MAX_SIZE,
+        HARDWARE_DUMP_MIN_SPACE_REQD, HARDWARE_DUMP_TOTAL_SIZE));
 
     try
     {
@@ -85,8 +85,8 @@ void loadExtensions(sdbusplus::bus::bus& bus,
     dumpList.push_back(
         std::make_unique<
             openpower::dump::hostdump::Manager<openpower::dump::sbe::Entry>>(
-            bus, event, SBE_DUMP_OBJPATH, SBE_DUMP_OBJ_ENTRY, SBE_DUMP_PATH,
-            "sbedump", SBE_DUMP_TMP_FILE_DIR, SBE_DUMP_MAX_SIZE,
+            bus, event, SBE_DUMP_OBJPATH, SBE_DUMP_OBJ_ENTRY, SBE_DUMP_START_ID,
+            SBE_DUMP_PATH, "sbedump", SBE_DUMP_TMP_FILE_DIR, SBE_DUMP_MAX_SIZE,
             SBE_DUMP_MIN_SPACE_REQD, SBE_DUMP_TOTAL_SIZE));
 }
 } // namespace dump

--- a/dump-extensions/openpower-dumps/dump_manager_hostdump.hpp
+++ b/dump-extensions/openpower-dumps/dump_manager_hostdump.hpp
@@ -71,6 +71,7 @@ class Manager :
      *  @param[in] event - Dump manager sd_event loop.
      *  @param[in] path - Path to attach at.
      *  @param[in] baseEntryPath - Base path for dump entry.
+     *  @param[in] startingId - Starting dump id
      *  @param[in] filePath - Path where the dumps are stored.
      *  @param[in] dumpNamePrefix - Prefix to the dump filename
      *  @param[in] dumpTempFileDir - Temporary location of dump files
@@ -80,12 +81,13 @@ class Manager :
      */
     Manager(sdbusplus::bus::bus& bus, const phosphor::dump::EventPtr& event,
             const char* path, const std::string& baseEntryPath,
-            const char* filePath, const std::string dumpNamePrefix,
-            const std::string dumpTempFileDir, const uint64_t maxDumpSize,
-            const uint64_t minDumpSize, const uint64_t allocatedSize) :
+            uint32_t startingId, const char* filePath,
+            const std::string dumpNamePrefix, const std::string dumpTempFileDir,
+            const uint64_t maxDumpSize, const uint64_t minDumpSize,
+            const uint64_t allocatedSize) :
         CreateIface(bus, path),
         phosphor::dump::bmc_stored::Manager(
-            bus, event, path, baseEntryPath, filePath,
+            bus, event, path, baseEntryPath, startingId, filePath,
             dumpNamePrefix + HOST_DUMP_COMMON_FILENAME_PART, maxDumpSize,
             minDumpSize, allocatedSize),
         dumpNamePrefix(dumpNamePrefix), dumpTempFileDir(dumpTempFileDir)

--- a/dump-extensions/openpower-dumps/meson.build
+++ b/dump-extensions/openpower-dumps/meson.build
@@ -37,6 +37,10 @@ opconf_data.set('HOSTBOOT_DUMP_MIN_SPACE_REQD', get_option('HOSTBOOT_DUMP_MIN_SP
 opconf_data.set('HOSTBOOT_DUMP_TOTAL_SIZE', get_option('HOSTBOOT_DUMP_TOTAL_SIZE'),
                description : 'Total size of the dump in kilo bytes'
              )
+opconf_data.set('HOSTBOOT_DUMP_START_ID', get_option('HOSTBOOT_DUMP_START_ID'),
+               description : 'Starting id of Hostboot dump'
+            )
+
 opconf_data.set_quoted('HARDWARE_DUMP_OBJPATH', get_option('HARDWARE_DUMP_OBJPATH'),
                       description : 'The hardware dump manager D-Bus path'
                     )
@@ -57,6 +61,9 @@ opconf_data.set('HARDWARE_DUMP_MIN_SPACE_REQD', get_option('HARDWARE_DUMP_MIN_SP
              )
 opconf_data.set('HARDWARE_DUMP_TOTAL_SIZE', get_option('HARDWARE_DUMP_TOTAL_SIZE'),
                description : 'Total size of the dump in kilo bytes'
+            )
+opconf_data.set('HARDWARE_DUMP_START_ID', get_option('HARDWARE_DUMP_START_ID'),
+               description : 'Starting id of Hardware dump'
             )
 
 opconf_data.set_quoted('SBE_DUMP_OBJPATH', get_option('SBE_DUMP_OBJPATH'),
@@ -79,6 +86,9 @@ opconf_data.set('SBE_DUMP_MIN_SPACE_REQD', get_option('SBE_DUMP_MIN_SPACE_REQD')
              )
 opconf_data.set('SBE_DUMP_TOTAL_SIZE', get_option('SBE_DUMP_TOTAL_SIZE'),
                description : 'Total size of the dump in kilo bytes'
+            )
+opconf_data.set('SBE_DUMP_START_ID', get_option('SBE_DUMP_START_ID'),
+               description : 'Starting id of SBE dump'
             )
 
 configure_file(configuration : opconf_data,

--- a/dump_manager.hpp
+++ b/dump_manager.hpp
@@ -45,6 +45,18 @@ class Manager : public Iface
         bus(bus), lastEntryId(0), baseEntryPath(baseEntryPath)
     {}
 
+    /** @brief Constructor to put object onto bus at a dbus path.
+     *  @param[in] bus - Bus to attach to.
+     *  @param[in] path - Path to attach at.
+     *  @param[in] baseEntryPath - Base path of the dump entry.
+     *  @param[in] startingId - Starting id of the dump.
+     */
+    Manager(sdbusplus::bus::bus& bus, const char* path,
+            const std::string& baseEntryPath, uint32_t startingId) :
+        Iface(bus, path, true),
+        bus(bus), lastEntryId(startingId), baseEntryPath(baseEntryPath)
+    {}
+
     /** @brief Construct dump d-bus objects from their persisted
      *        representations.
      */

--- a/dump_manager_bmcstored.hpp
+++ b/dump_manager_bmcstored.hpp
@@ -56,6 +56,35 @@ class Manager : public phosphor::dump::Manager
         minDumpSize(minDumpSize), allocatedSize(allocatedSize)
     {}
 
+    /** @brief Constructor to put object onto bus at a dbus path.
+     *  @param[in] bus - Bus to attach to.
+     *  @param[in] event - Dump manager sd_event loop.
+     *  @param[in] path - Path to attach at.
+     *  @param[in] baseEntryPath - Base path for dump entry.
+     *  @param[in] startingId - Starting id of the dump
+     *  @param[in] filePath - Path where the dumps are stored.
+     *  @param[in] dumpFilenameFormat - Format of dump filename in regex
+     *  @param[in] maxDumpSize - Maximum size of the dump
+     *  @param[in] minDumpSize - Minimum possible size of a usable dump.
+     *  @param[in] allocatedSize - Total size allocated for the dumps
+     */
+    Manager(sdbusplus::bus::bus& bus, const EventPtr& event, const char* path,
+            const std::string& baseEntryPath, uint32_t startingId,
+            const char* filePath, const std::string dumpFilenameFormat,
+            const uint64_t maxDumpSize, const uint64_t minDumpSize,
+            const uint64_t allocatedSize) :
+        phosphor::dump::Manager(bus, path, baseEntryPath, startingId),
+        dumpDir(filePath), eventLoop(event.get()),
+        dumpWatch(
+            eventLoop, IN_NONBLOCK, IN_CLOSE_WRITE | IN_CREATE, EPOLLIN,
+            filePath,
+            std::bind(std::mem_fn(
+                          &phosphor::dump::bmc_stored::Manager::watchCallback),
+                      this, std::placeholders::_1)),
+        dumpFilenameFormat(dumpFilenameFormat), maxDumpSize(maxDumpSize),
+        minDumpSize(minDumpSize), allocatedSize(allocatedSize)
+    {}
+
     /** @brief Implementation of dump watch call back
      *  @param [in] fileInfo - map of file info  path:event
      */

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -183,6 +183,10 @@ option('HOSTBOOT_DUMP_TOTAL_SIZE', type : 'integer',
         value : 409600,
         description : 'Total size of the dump in kilo bytes'
       )
+option('HOSTBOOT_DUMP_START_ID', type : 'integer',
+        value : 20000000,
+        description : 'Starting id of Hostboot Dump'
+      )
 
 # Hardware dump options
 
@@ -220,6 +224,10 @@ option('HARDWARE_DUMP_TOTAL_SIZE', type : 'integer',
         value : 409600,
         description : 'Total size of the hardware dump in kilo bytes'
       )
+option('HARDWARE_DUMP_START_ID', type : 'integer',
+        value : 0,
+        description : 'Starting id of Hardware Dump'
+      )
 
 # SBE dump options
 
@@ -256,4 +264,8 @@ option('SBE_DUMP_MIN_SPACE_REQD', type : 'integer',
 option('SBE_DUMP_TOTAL_SIZE', type : 'integer',
         value : 409600,
         description : 'Total size of the SBE dump in kilo bytes'
+      )
+option('SBE_DUMP_START_ID', type : 'integer',
+        value : 30000000,
+        description : 'Starting id of SBE Dump'
       )


### PR DESCRIPTION
Host dump ids need to be started from certain numbers
this commit adds the starting if for each type of dumps

Hardare dump: Starting ID - 0
Hostboot dump: Starting ID - 20000001
SBE dump: Starting ID - 30000001

Signed-off-by: Dhruvaraj Subhashchandran <dhruvaraj@in.ibm.com>
Change-Id: I26945184c727e70fb9f543eaa7c2266a650b2793