### PR TITLE
Remove host running check for system dump

### DIFF
--- a/dump-extensions/openpower-dumps/system_dump_entry.cpp
+++ b/dump-extensions/openpower-dumps/system_dump_entry.cpp
@@ -20,17 +20,6 @@ using namespace phosphor::logging;
 
 void Entry::initiateOffload(std::string uri)
 {
-    using NotAllowed =
-        sdbusplus::xyz::openbmc_project::Common::Error::NotAllowed;
-    using Reason = xyz::openbmc_project::Common::NotAllowed::REASON;
-
-    // Allow offloading only when the host is up.
-    if (!phosphor::dump::isHostRunning())
-    {
-        elog<NotAllowed>(
-            Reason("System dump can be offloaded only when the host is up"));
-        return;
-    }
     phosphor::dump::Entry::initiateOffload(uri);
     phosphor::dump::host::requestOffload(sourceDumpId());
 }


### PR DESCRIPTION
The check for host running was added for the
operations on the dumps stored in the host
but in the case of request for offload The system dump
is ready to offload as soon as it is ready in the host.
The state of the host in the BMC may not be updated by
then, so it is not reliable to depend on the host state
in the BMC and if the host is not ready there will be an
error from PLDM.

This commit is for removing the host running check before
sending the initiate offload request to host. The check
for other operations like delete or initiate will not
be impacted

Review link: https://gerrit.openbmc-project.xyz/c/openbmc/phosphor-debug-collector/+/50239

Signed-off-by: Dhruvaraj Subhashchandran <dhruvaraj@in.ibm.com>
Change-Id: I665485c7605b54fe4f361ec73e2bff9bba87c49e