### PR TITLE
Fixes for dump manager 

### DIFF
--- a/dump-extensions/openpower-dumps/clear_hostdumps_poweroff.service
+++ b/dump-extensions/openpower-dumps/clear_hostdumps_poweroff.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Remove host dump entries during poweroff
+Wants=obmc-host-stop-pre@0.target
+After=obmc-host-stop-pre@0.target
+Wants=obmc-host-stopping@0.target
+Before=obmc-host-stopping@0.target
+Conflicts=obmc-host-startmin@0.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/busctl call xyz.openbmc_project.Dump.Manager /xyz/openbmc_project/dump/resource xyz.openbmc_project.Collection.DeleteAll  DeleteAll
+ExecStart=/usr/bin/busctl call xyz.openbmc_project.Dump.Manager /xyz/openbmc_project/dump/system xyz.openbmc_project.Collection.DeleteAll  DeleteAll
+RemainAfterExit=yes
+
+[Install]
+WantedBy=obmc-host-stop@0.target

--- a/dump-extensions/openpower-dumps/dump_manager_resource.cpp
+++ b/dump-extensions/openpower-dumps/dump_manager_resource.cpp
@@ -3,7 +3,6 @@
 #include "dump_manager_resource.hpp"
 
 #include "dump_utils.hpp"
-#include "op_dump_util.hpp"
 #include "resource_dump_entry.hpp"
 #include "xyz/openbmc_project/Common/error.hpp"
 
@@ -82,9 +81,6 @@ sdbusplus::message::object_path
     using NotAllowed =
         sdbusplus::xyz::openbmc_project::Common::Error::NotAllowed;
     using Reason = xyz::openbmc_project::Common::NotAllowed::REASON;
-
-    // Check dump policy
-    util::isOPDumpsEnabled();
 
     // Allow creating resource dump only when the host is up.
     if (!phosphor::dump::isHostRunning())

--- a/dump-extensions/openpower-dumps/dump_manager_system.cpp
+++ b/dump-extensions/openpower-dumps/dump_manager_system.cpp
@@ -3,7 +3,6 @@
 #include "dump_manager_system.hpp"
 
 #include "dump_utils.hpp"
-#include "op_dump_util.hpp"
 #include "system_dump_entry.hpp"
 #include "xyz/openbmc_project/Common/error.hpp"
 
@@ -88,9 +87,6 @@ sdbusplus::message::object_path
         log<level::WARNING>(
             "System dump accepts not more than 1 additional parameter");
     }
-
-    // Check dump policy
-    util::isOPDumpsEnabled();
 
     using NotAllowed =
         sdbusplus::xyz::openbmc_project::Common::Error::NotAllowed;

--- a/dump-extensions/openpower-dumps/meson.build
+++ b/dump-extensions/openpower-dumps/meson.build
@@ -1,5 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
+unit_files += {'input': 'dump-extensions/openpower-dumps/clear_hostdumps_poweroff.service',
+         'output': 'clear_hostdumps_poweroff.service'}
+
 # Configuration header file(openpower_dumps_config.h) generation
 opconf_data = configuration_data()
 

--- a/meson.build
+++ b/meson.build
@@ -15,6 +15,11 @@ project('phosphor-debug-collector',
 
 cpp = meson.get_compiler('cpp')
 
+# list of unit files, the path as input and service name
+# as output
+# eg: unit_file += {'input:'<path>, 'output':<service name>}
+unit_files = []
+
 # Checking dependency external library
 
 libsystemd = dependency('libsystemd', version : '>=221')
@@ -256,6 +261,21 @@ foreach executable : executables
                         install : executable[3],
                         include_directories : executable[4]
                        )
+endforeach
+
+unit_subs = configuration_data()
+unit_subs.set('bindir', join_paths(get_option('prefix'), get_option('bindir')))
+systemd_system_unit_dir = dependency('systemd').get_pkgconfig_variable(
+    'systemdsystemunitdir',
+    define_variable: ['prefix', get_option('prefix')])
+foreach u : unit_files
+    configure_file(
+        configuration: unit_subs,
+        input: u.get('input'),
+        install: true,
+        install_dir: systemd_system_unit_dir,
+        output: u.get('output')
+    )
 endforeach
 
 if get_option('tests').enabled()


### PR DESCRIPTION
Following fixes are added
1. OpenPOWER: Clear system and resource dump entries while powering off
     https://gerrit.openbmc-project.xyz/c/openbmc/phosphor-debug-collector/+/43125

2. Allow user initiated dumps even when policy is disabled
    https://gerrit.openbmc-project.xyz/c/openbmc/phosphor-debug-collector/+/49781