### PR TITLE
Fixes for dump offload to host OS 

### DIFF
--- a/bmcstored_dump_entry.cpp
+++ b/bmcstored_dump_entry.cpp
@@ -19,13 +19,15 @@ void Entry::delete_()
     // Delete Dump file from Permanent location
     try
     {
-        std::filesystem::remove_all(file.parent_path());
+        std::filesystem::remove_all(
+            std::filesystem::path(path()).parent_path());
     }
     catch (const std::filesystem::filesystem_error& e)
     {
         // Log Error message and continue
         log<level::ERR>(
-            fmt::format("Failed to delete dump file, errormsg({})", e.what())
+            fmt::format("Failed to delete dump file({}), errormsg({})", path(),
+                        e.what())
                 .c_str());
     }
 
@@ -35,7 +37,7 @@ void Entry::delete_()
 
 void Entry::initiateOffload(std::string uri)
 {
-    phosphor::dump::offload::requestOffload(file, id, uri);
+    phosphor::dump::offload::requestOffload(path(), id, uri);
     offloaded(true);
 }
 

--- a/bmcstored_dump_entry.hpp
+++ b/bmcstored_dump_entry.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "dump_entry.hpp"
+#include "xyz/openbmc_project/Common/FilePath/server.hpp"
 #include "xyz/openbmc_project/Dump/Entry/server.hpp"
 #include "xyz/openbmc_project/Object/Delete/server.hpp"
 #include "xyz/openbmc_project/Time/EpochTime/server.hpp"
@@ -16,6 +17,10 @@ namespace dump
 {
 namespace bmc_stored
 {
+template <typename T>
+using ServerObject = typename sdbusplus::server::object::object<T>;
+using FileIfaces = sdbusplus::server::object::object<
+    sdbusplus::xyz::openbmc_project::Common::server::FilePath>;
 
 class Manager;
 
@@ -24,7 +29,7 @@ class Manager;
  *  @details A concrete implementation for the
  *  xyz.openbmc_project.Dump.Entry DBus API
  */
-class Entry : public phosphor::dump::Entry
+class Entry : public phosphor::dump::Entry, public FileIfaces
 {
   public:
     Entry() = delete;
@@ -52,8 +57,10 @@ class Entry : public phosphor::dump::Entry
           phosphor::dump::Manager& parent) :
         phosphor::dump::Entry(bus, objPath.c_str(), dumpId, timeStamp, fileSize,
                               status, parent),
-        file(file)
-    {}
+        FileIfaces(bus, objPath.c_str(), true)
+    {
+        path(file);
+    }
 
     /** @brief Delete this d-bus object.
      */
@@ -78,7 +85,7 @@ class Entry : public phosphor::dump::Entry
         size(fileSize);
         // TODO: Handled dump failed case with #ibm-openbmc/2808
         status(OperationStatus::Completed);
-        file = filePath;
+        path(filePath);
         // TODO: serialization of this property will be handled with
         // #ibm-openbmc/2597
         completedTime(timeStamp);

--- a/dump-extensions/openpower-dumps/dump_manager_resource.cpp
+++ b/dump-extensions/openpower-dumps/dump_manager_resource.cpp
@@ -3,6 +3,7 @@
 #include "dump_manager_resource.hpp"
 
 #include "dump_utils.hpp"
+#include "op_dump_consts.hpp"
 #include "resource_dump_entry.hpp"
 #include "xyz/openbmc_project/Common/error.hpp"
 

--- a/dump-extensions/openpower-dumps/dump_manager_resource.hpp
+++ b/dump-extensions/openpower-dumps/dump_manager_resource.hpp
@@ -15,7 +15,6 @@ namespace dump
 namespace resource
 {
 
-constexpr uint32_t INVALID_SOURCE_ID = 0xFFFFFFFF;
 using NotifyIface = sdbusplus::server::object::object<
     sdbusplus::xyz::openbmc_project::Dump::server::Create,
     sdbusplus::com::ibm::Dump::server::Create,

--- a/dump-extensions/openpower-dumps/dump_manager_system.cpp
+++ b/dump-extensions/openpower-dumps/dump_manager_system.cpp
@@ -3,6 +3,7 @@
 #include "dump_manager_system.hpp"
 
 #include "dump_utils.hpp"
+#include "op_dump_consts.hpp"
 #include "system_dump_entry.hpp"
 #include "xyz/openbmc_project/Common/error.hpp"
 

--- a/dump-extensions/openpower-dumps/dump_manager_system.hpp
+++ b/dump-extensions/openpower-dumps/dump_manager_system.hpp
@@ -15,7 +15,6 @@ namespace dump
 namespace system
 {
 
-constexpr uint32_t INVALID_SOURCE_ID = 0xFFFFFFFF;
 using NotifyIface = sdbusplus::server::object::object<
     sdbusplus::xyz::openbmc_project::Dump::server::Create,
     sdbusplus::xyz::openbmc_project::Dump::server::NewDump>;

--- a/dump-extensions/openpower-dumps/op_dump_consts.hpp
+++ b/dump-extensions/openpower-dumps/op_dump_consts.hpp
@@ -1,0 +1,3 @@
+#pragma once
+
+constexpr uint32_t INVALID_SOURCE_ID = 0xFFFFFFFF;

--- a/dump-extensions/openpower-dumps/resource_dump_entry.cpp
+++ b/dump-extensions/openpower-dumps/resource_dump_entry.cpp
@@ -2,6 +2,7 @@
 
 #include "dump_utils.hpp"
 #include "host_transport_exts.hpp"
+#include "op_dump_consts.hpp"
 
 #include <phosphor-logging/elog-errors.hpp>
 #include <xyz/openbmc_project/Common/error.hpp>
@@ -43,7 +44,7 @@ void Entry::delete_()
 
     // Remove resource dump when host is up by using source dump id
     // which is present in resource dump entry dbus object as a property.
-    if (phosphor::dump::isHostRunning())
+    if ((phosphor::dump::isHostRunning()) && (srcDumpID != INVALID_SOURCE_ID))
     {
         phosphor::dump::host::requestDelete(srcDumpID,
                                             TRANSPORT_DUMP_TYPE_IDENTIFIER);

--- a/dump-extensions/openpower-dumps/system_dump_entry.cpp
+++ b/dump-extensions/openpower-dumps/system_dump_entry.cpp
@@ -2,6 +2,7 @@
 
 #include "dump_utils.hpp"
 #include "host_transport_exts.hpp"
+#include "op_dump_consts.hpp"
 
 #include <phosphor-logging/elog-errors.hpp>
 #include <xyz/openbmc_project/Common/error.hpp>
@@ -33,7 +34,7 @@ void Entry::delete_()
 
     // Remove host system dump when host is up by using source dump id
     // which is present in system dump entry dbus object as a property.
-    if (phosphor::dump::isHostRunning())
+    if ((phosphor::dump::isHostRunning()) && (srcDumpID != INVALID_SOURCE_ID))
     {
         phosphor::dump::host::requestDelete(srcDumpID,
                                             TRANSPORT_DUMP_TYPE_IDENTIFIER);


### PR DESCRIPTION
1 - Make dump file path as dbus property: https://gerrit.openbmc-project.xyz/c/openbmc/phosphor-debug-collector/+/49466

2 - Fix in delete dump command from host os: https://gerrit.openbmc-project.xyz/c/openbmc/phosphor-debug-collector/+/50456