### PR TITLE
Fixes for avoding duplicate host stored dumps

### DIFF
--- a/dump-extensions/openpower-dumps/dump_manager_resource.cpp
+++ b/dump-extensions/openpower-dumps/dump_manager_resource.cpp
@@ -28,24 +28,49 @@ void Manager::notify(uint32_t dumpId, uint64_t size)
     // Get the timestamp
     std::time_t timeStamp = std::time(nullptr);
 
-    // If there is an entry with this sourceId or an invalid id
-    // update that.
-    // If host is sending the source id before the completion
-    // the source id will be updated by the transport layer with host.
-    // if not the source id will stay as invalid one.
+    // If there is an entry with invalid id update that.
+    // If there a completed one with same source id ignore it
+    // if there is no invalid id, create new entry
+    openpower::dump::resource::Entry* upEntry = NULL;
     for (auto& entry : entries)
     {
         openpower::dump::resource::Entry* resEntry =
             dynamic_cast<openpower::dump::resource::Entry*>(entry.second.get());
-        if ((resEntry->status() ==
-             phosphor::dump::OperationStatus::InProgress) &&
-            ((resEntry->sourceDumpId() == dumpId) ||
-             (resEntry->sourceDumpId() == INVALID_SOURCE_ID)))
+
+        // If there is already a completed entry with input source id then
+        // ignore this notification.
+        if ((resEntry->sourceDumpId() == dumpId) &&
+            (resEntry->status() == phosphor::dump::OperationStatus::Completed))
         {
-            resEntry->update(timeStamp, size, dumpId);
+            log<level::INFO>(
+                fmt::format("Resource dump entry with source dump id({}) is "
+                            "already present with entry id({})",
+                            dumpId, resEntry->getDumpId())
+                    .c_str());
             return;
         }
+
+        // Save the fist entry with INVALID_SOURCE_ID
+        // but continue in the loop to make sure the
+        // new entry is not duplicate
+        if ((resEntry->status() ==
+             phosphor::dump::OperationStatus::InProgress) &&
+            (resEntry->sourceDumpId() == INVALID_SOURCE_ID) &&
+            (upEntry == NULL))
+        {
+            upEntry = resEntry;
+        }
     }
+    if (upEntry != NULL)
+    {
+        log<level::INFO>(fmt::format("Resouce Dump Notify: Updating dumpId({}) "
+                                     "with source Id({}) Size({})",
+                                     upEntry->getDumpId(), dumpId, size)
+                             .c_str());
+        upEntry->update(timeStamp, size, dumpId);
+        return;
+    }
+
     // Get the id
     auto id = lastEntryId + 1;
     auto idString = std::to_string(id);
@@ -56,6 +81,10 @@ void Manager::notify(uint32_t dumpId, uint64_t size)
 
     try
     {
+        log<level::INFO>(fmt::format("Resouce Dump Notify: creating new dump "
+                                     "entry dumpId({}) Id({}) Size({})",
+                                     id, dumpId, size)
+                             .c_str());
         entries.insert(std::make_pair(
             id, std::make_unique<resource::Entry>(
                     bus, objPath.c_str(), id, timeStamp, size, dumpId,

--- a/dump-extensions/openpower-dumps/dump_manager_system.cpp
+++ b/dump-extensions/openpower-dumps/dump_manager_system.cpp
@@ -34,15 +34,43 @@ void Manager::notify(uint32_t dumpId, uint64_t size)
     // entry will be created first with invalid source id.
     // Since there can be only one system dump creation at a time,
     // if there is an entry with invalid sourceId update that.
+    openpower::dump::system::Entry* upEntry = NULL;
     for (auto& entry : entries)
     {
         openpower::dump::system::Entry* sysEntry =
             dynamic_cast<openpower::dump::system::Entry*>(entry.second.get());
-        if (sysEntry->sourceDumpId() == INVALID_SOURCE_ID)
+
+        // If there is already a completed entry with input source id then
+        // ignore this notification
+        if ((sysEntry->sourceDumpId() == dumpId) &&
+            (sysEntry->status() == phosphor::dump::OperationStatus::Completed))
         {
-            sysEntry->update(timeStamp, size, dumpId);
+            log<level::INFO>(
+                fmt::format("System dump entry with source dump id({}) is "
+                            "already present with entry id({})",
+                            dumpId, sysEntry->getDumpId())
+                    .c_str());
             return;
         }
+
+        // Save the fist entry with INVALID_SOURCE_ID
+        // but continue in the loop to make sure the
+        // new entry is not duplicate
+        if ((sysEntry->sourceDumpId() == INVALID_SOURCE_ID) &&
+            (upEntry == NULL))
+        {
+            upEntry = sysEntry;
+        }
+    }
+
+    if (upEntry != NULL)
+    {
+        log<level::INFO>(
+            fmt::format(
+                "System Dump Notify: Updating dumpId({}) Id({}) Size({})",
+                upEntry->getDumpId(), dumpId, size)
+                .c_str());
+        upEntry->update(timeStamp, size, dumpId);
     }
 
     // Get the id
@@ -54,6 +82,10 @@ void Manager::notify(uint32_t dumpId, uint64_t size)
     // For now replacing it with null
     try
     {
+        log<level::INFO>(fmt::format("System Dump Notify: creating new dump "
+                                     "entry dumpId({}) Id({}) Size({})",
+                                     id, dumpId, size)
+                             .c_str());
         entries.insert(std::make_pair(
             id, std::make_unique<system::Entry>(
                     bus, objPath.c_str(), id, timeStamp, size, dumpId,

--- a/dump_entry.hpp
+++ b/dump_entry.hpp
@@ -97,6 +97,14 @@ class Entry : public EntryIfaces
         offloadUri(uri);
     }
 
+    /** @brief Returns the dump id
+     *  @return the id associated with entry
+     */
+    uint32_t getDumpId()
+    {
+        return id;
+    }
+
   protected:
     /** @brief This entry's parent */
     Manager& parent;


### PR DESCRIPTION
50815: Add method to get dump id | https://gerrit.openbmc-project.xyz/c/openbmc/phosphor-debug-collector/+/50815

50817: Ignore already reported resource dump | https://gerrit.openbmc-project.xyz/c/openbmc/phosphor-debug-collector/+/50817

50818: Ignore dupliate system dump entry | https://gerrit.openbmc-project.xyz/c/openbmc/phosphor-debug-collector/+/50818