### PR TITLE
Fix for resource dump delete

### DIFF
--- a/dump-extensions/openpower-dumps/resource_dump_entry.cpp
+++ b/dump-extensions/openpower-dumps/resource_dump_entry.cpp
@@ -26,6 +26,11 @@ void Entry::initiateOffload(std::string uri)
     using NotAllowed =
         sdbusplus::xyz::openbmc_project::Common::Error::NotAllowed;
     using Reason = xyz::openbmc_project::Common::NotAllowed::REASON;
+    log<level::INFO>(
+        fmt::format(
+            "Resource dump offload request id({}) uri({}) source dumpid()", id,
+            uri, sourceDumpId())
+            .c_str());
 
     if (!phosphor::dump::isHostRunning())
     {

--- a/dump-extensions/openpower-dumps/resource_dump_entry.cpp
+++ b/dump-extensions/openpower-dumps/resource_dump_entry.cpp
@@ -4,6 +4,8 @@
 #include "host_transport_exts.hpp"
 #include "op_dump_consts.hpp"
 
+#include <fmt/core.h>
+
 #include <phosphor-logging/elog-errors.hpp>
 #include <xyz/openbmc_project/Common/error.hpp>
 
@@ -38,7 +40,10 @@ void Entry::initiateOffload(std::string uri)
 void Entry::delete_()
 {
     auto srcDumpID = sourceDumpId();
-
+    auto dumpId = id;
+    log<level::INFO>(fmt::format("Resource dump delete id({}) srcdumpid({})",
+                                 dumpId, srcDumpID)
+                         .c_str());
     // Remove Dump entry D-bus object
     phosphor::dump::Entry::delete_();
 
@@ -49,6 +54,9 @@ void Entry::delete_()
         phosphor::dump::host::requestDelete(srcDumpID,
                                             TRANSPORT_DUMP_TYPE_IDENTIFIER);
     }
+    log<level::INFO>(
+        fmt::format("Resource dump entry with id({}) is deleted", dumpId)
+            .c_str());
 }
 } // namespace resource
 } // namespace dump

--- a/dump-extensions/openpower-dumps/system_dump_entry.cpp
+++ b/dump-extensions/openpower-dumps/system_dump_entry.cpp
@@ -4,6 +4,8 @@
 #include "host_transport_exts.hpp"
 #include "op_dump_consts.hpp"
 
+#include <fmt/core.h>
+
 #include <phosphor-logging/elog-errors.hpp>
 #include <xyz/openbmc_project/Common/error.hpp>
 
@@ -21,6 +23,11 @@ using namespace phosphor::logging;
 
 void Entry::initiateOffload(std::string uri)
 {
+    log<level::INFO>(
+        fmt::format(
+            "System dump offload request id({}) uri({}) source dumpid()", id,
+            uri, sourceDumpId())
+            .c_str());
     phosphor::dump::Entry::initiateOffload(uri);
     phosphor::dump::host::requestOffload(sourceDumpId());
 }
@@ -28,6 +35,10 @@ void Entry::initiateOffload(std::string uri)
 void Entry::delete_()
 {
     auto srcDumpID = sourceDumpId();
+    auto dumpId = id;
+    log<level::INFO>(fmt::format("System dump delete id({}) srcdumpid({})",
+                                 dumpId, srcDumpID)
+                         .c_str());
 
     // Remove Dump entry D-bus object
     phosphor::dump::Entry::delete_();
@@ -39,6 +50,9 @@ void Entry::delete_()
         phosphor::dump::host::requestDelete(srcDumpID,
                                             TRANSPORT_DUMP_TYPE_IDENTIFIER);
     }
+    log<level::INFO>(
+        fmt::format("System dump entry with id({}) is deleted", dumpId)
+            .c_str());
 }
 } // namespace system
 } // namespace dump


### PR DESCRIPTION
Do not wait for a response deleting host dump

The resource dump delete is long-running operation with
dbus call to PLDM for instance id, making it inside a
dbus call will end up timeouts when PLDM tries to
access dump manager. To avoid dead-locks dump manager
will not be waiting for a response after a delete
operation

Testing:
   Create system dump and delete the dump
   Create 10 resource dumps and delete them one by one

https://gerrit.openbmc-project.xyz/c/openbmc/phosphor-debug-collector/+/50884/4

50922: Add additional trace to host dump operations | https://gerrit.openbmc-project.xyz/c/openbmc/phosphor-debug-collector/+/50922