### PR TITLE
openPower: Removing serial files during delete operation

### DIFF
--- a/dump-extensions/openpower-dumps/resource_dump_entry.cpp
+++ b/dump-extensions/openpower-dumps/resource_dump_entry.cpp
@@ -61,11 +61,27 @@ void Entry::delete_()
 {
     auto srcDumpID = sourceDumpId();
     auto dumpId = id;
-    log<level::INFO>(fmt::format("Resource dump delete id({}) srcdumpid({})",
-                                 dumpId, srcDumpID)
-                         .c_str());
+    auto path = std::filesystem::path(RESOURCE_DUMP_SERIAL_PATH) /
+                std::to_string(dumpId);
+    log<level::INFO>(
+        fmt::format(
+            "Resource dump delete id({}) srcdumpid({}) and serial path({})",
+            dumpId, srcDumpID, path.string().c_str())
+            .c_str());
     // Remove Dump entry D-bus object
     phosphor::dump::Entry::delete_();
+    try
+    {
+        std::filesystem::remove_all(path);
+    }
+    catch (const std::filesystem::filesystem_error& e)
+    {
+        // Log Error message and continue
+        log<level::ERR>(
+            fmt::format("Failed to delete dump file({}), errormsg({})",
+                        path.string().c_str(), e.what())
+                .c_str());
+    }
 
     // Remove resource dump when host is up by using source dump id
     // which is present in resource dump entry dbus object as a property.

--- a/dump-extensions/openpower-dumps/system_dump_entry.cpp
+++ b/dump-extensions/openpower-dumps/system_dump_entry.cpp
@@ -37,12 +37,28 @@ void Entry::delete_()
 {
     auto srcDumpID = sourceDumpId();
     auto dumpId = id;
-    log<level::INFO>(fmt::format("System dump delete id({}) srcdumpid({})",
-                                 dumpId, srcDumpID)
-                         .c_str());
+    auto path =
+        std::filesystem::path(SYSTEM_DUMP_SERIAL_PATH) / std::to_string(dumpId);
+    log<level::INFO>(
+        fmt::format(
+            "System dump delete id({}) srcdumpid({}) and serial path({})",
+            dumpId, srcDumpID, path.string().c_str())
+            .c_str());
 
     // Remove Dump entry D-bus object
     phosphor::dump::Entry::delete_();
+    try
+    {
+        std::filesystem::remove_all(path);
+    }
+    catch (const std::filesystem::filesystem_error& e)
+    {
+        // Log Error message and continue
+        log<level::ERR>(
+            fmt::format("Failed to delete dump file({}), errormsg({})",
+                        path.string().c_str(), e.what())
+                .c_str());
+    }
 
     // Remove host system dump when host is up by using source dump id
     // which is present in system dump entry dbus object as a property.


### PR DESCRIPTION
Changes:
-Deleting the serialization files of system and resource dumps,
which are used to restore the dbus entries, when delete
entry operation is called need to delete the files from the path,
so that the entries don't get populate again.

Tested:
-Created resource and system dump, this operation creates serial
files for respective dumps. After issuing delete operation, can see
the files from serial path is getting deleted.

Gerrit link: https://gerrit.openbmc-project.xyz/c/openbmc/phosphor-debug-collector/+/51513

Signed-off-by: Chirag Sharma <chirshar@in.ibm.com>
Change-Id: I4ee7accda3eaf4a8c8641739153478ddd97f6c84