### PR TITLE
Updates to dreport and host dump clear

### DIFF
--- a/dump-extensions/openpower-dumps/clear_hostdumps_poweroff.service
+++ b/dump-extensions/openpower-dumps/clear_hostdumps_poweroff.service
@@ -5,6 +5,7 @@ After=obmc-host-stop-pre@0.target
 Wants=obmc-host-stopping@0.target
 Before=obmc-host-stopping@0.target
 Conflicts=obmc-host-startmin@0.target
+ConditionPathExists=!/run/openbmc/mpreboot@0
 
 [Service]
 Type=oneshot

--- a/dump-extensions/openpower-dumps/clear_hostdumps_poweroff.service
+++ b/dump-extensions/openpower-dumps/clear_hostdumps_poweroff.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=Remove host dump entries during poweroff
+Description=Remove entries of dumps stored in the host memory during poweroff
 Wants=obmc-host-stop-pre@0.target
 After=obmc-host-stop-pre@0.target
 Wants=obmc-host-stopping@0.target

--- a/tools/dreport.d/include.d/functions
+++ b/tools/dreport.d/include.d/functions
@@ -33,7 +33,7 @@ function add_copy_file()
     file_name="$1"
     desc="$2"
 
-    cp -r $file_name $name_dir
+    cp -Lr $file_name $name_dir
     if [ $? -ne 0 ]; then
         log_error "Failed to copy $desc $file_name"
         return $RESOURCE_UNAVAILABLE

--- a/tools/dreport.d/include.d/functions
+++ b/tools/dreport.d/include.d/functions
@@ -42,8 +42,8 @@ function add_copy_file()
         log_info "Copied $desc $file_name"
         return $SUCCESS
     else
-        return $RESOURCE_UNAVAILABLE
         log_warning "Skipping copy $desc $file_name"
+        return $RESOURCE_UNAVAILABLE
     fi
 }
 # @brief Copy the symbolic link file to the dreport packaging,

--- a/tools/dreport.d/plugins.d/dmesginfo
+++ b/tools/dreport.d/plugins.d/dmesginfo
@@ -1,0 +1,13 @@
+#!/bin/bash
+#
+# config: 2 20
+# @brief: Collect dmesg information.
+#
+
+. $DREPORT_INCLUDE/functions
+
+desc="dmesg"
+file_name="dmesg.log"
+command="dmesg"
+
+add_cmd_output "$command" "$file_name" "$desc"

--- a/tools/dreport.d/plugins.d/pldmflightrecorder
+++ b/tools/dreport.d/plugins.d/pldmflightrecorder
@@ -1,0 +1,23 @@
+#!/bin/bash
+#
+# config: 2 20
+# @brief: Get the pldm flight recorder
+#
+
+. $DREPORT_INCLUDE/functions
+
+desc="pldm flight recorder"
+
+# collect data only if pldmd is enabled
+if [ -e "/usr/bin/pldmd" ]; then
+  command="rm -rf /tmp/pldm_flight_recorder; killall -s SIGUSR1 pldmd; \
+           sleep 5; cat /tmp/pldm_flight_recorder"
+
+  file_name="pldmflightrecorder.log"
+
+  add_cmd_output "$command" "$file_name" "$desc"
+
+  rm -rf /tmp/pldm_flight_recorder
+else
+  log_warning "skipping pldm flight recorder:  pldmd is not enabled"
+fi


### PR DESCRIPTION
43125: OpenPOWER: Clear system and resource dump entries while powering off | https://gerrit.openbmc-project.xyz/c/openbmc/phosphor-debug-collector/+/43125

51516: OpenPOWER: Do not delete dump entries during mp reboot | https://gerrit.openbmc-project.xyz/c/openbmc/phosphor-debug-collector/+/51516

dreport: fix missing log messages related to skipping copy https://gerrit.openbmc-project.xyz/c/openbmc/phosphor-debug-collector/+/51305
dreport: fix symlinks copy https://gerrit.openbmc-project.xyz/c/openbmc/phosphor-debug-collector/+/51306/
dreport: Added pldmflightrecorder plugin https://gerrit.openbmc-project.xyz/c/openbmc/phosphor-debug-collector/+/51308/
dreport: Added dmesginfo plugin https://gerrit.openbmc-project.xyz/c/openbmc/phosphor-debug-collector/+/51308/
