### PR TITLE
opdreport: Fix to remove unwanted entries in journal

### DIFF
--- a/tools/dreport.d/ibm.d/gendumpinfo
+++ b/tools/dreport.d/ibm.d/gendumpinfo
@@ -10,8 +10,7 @@ declare -rx DUMP_PROP='xyz.openbmc_project.Common.Progress'
 declare -x DRIVER=$(cat /etc/os-release | grep VERSION_ID | \
 awk -F = '{ print $2}' | cut -d'(' -f 1)
 declare -x YAML_FILE="$optional_path/info.yaml"
-declare -x
-ADDL_DATA_PATH="$optional_path/plat_dump/additional_data/"
+declare -x ADDL_DATA_PATH="$optional_path/plat_dump/additional_data/"
 declare -x START_TIME=''
 declare -x END_TIME=''
 
@@ -51,7 +50,7 @@ function get_addl_data() {
         for entry in "$ADDL_DATA_PATH"/*
             do
                 while IFS= read -r line; do
-                    echo $line >> $YAML_FILE
+                    echo "$line" >> $YAML_FILE
                 done < $entry
             done
     fi


### PR DESCRIPTION
Change:
- Due to syntax issue, unwanted traces were seen in journal
during dump packing of hostdumps.

Tested:
- Post fixing the syntax issue. Not seeing unwanted traces in
the journal.

Gerrit Link: https://gerrit.openbmc-project.xyz/c/openbmc/phosphor-debug-collector/+/51634

Change-Id: Ibbace2d825fd10ed92a9dcaaf6d6ad67b5f207c6
Signed-off-by: Chirag Sharma <chirshar@in.ibm.com>