### PR TITLE
dreport: Added error handling support in badvpd

### DIFF
--- a/tools/dreport.d/ibm.d/badvpd
+++ b/tools/dreport.d/ibm.d/badvpd
@@ -9,4 +9,9 @@
 desc="Bad VPD"
 dir_name="/tmp/bad-vpd"
 
-add_copy_file "$dir_name" "$desc"
+if [ -f $dir_name ]; then
+    add_copy_file "$dir_name" "$desc"
+else
+    log_info "No $desc data"
+    exit
+fi


### PR DESCRIPTION
This is to fix below error message in the journal logs.
cp: can't stat '/tmp/bad-vpd': No such file or directory

"bad-vpd" is an optional file created vpd, to store the
failing data.

Tested:  verified using dreport command line tool
    "INFO: No Bad VPD data"

Signed-off-by: Jayanth Othayoth <ojayanth@in.ibm.com>
Change-Id: I56854c044d5479f48669736204d9b929fc5d8db5

Gerrit Link: https://gerrit.openbmc-project.xyz/c/openbmc/phosphor-debug-collector/+/51750