### PR TITLE
Host dump fixes

### DIFF
--- a/dump-extensions/openpower-dumps/clear_hostdumps_poweroff.service
+++ b/dump-extensions/openpower-dumps/clear_hostdumps_poweroff.service
@@ -5,7 +5,6 @@ After=obmc-host-stop-pre@0.target
 Wants=obmc-host-stopping@0.target
 Before=obmc-host-stopping@0.target
 Conflicts=obmc-host-startmin@0.target
-ConditionPathExists=!/run/openbmc/mpreboot@0
 
 [Service]
 Type=oneshot

--- a/dump-extensions/openpower-dumps/dump_manager_resource.cpp
+++ b/dump-extensions/openpower-dumps/dump_manager_resource.cpp
@@ -171,22 +171,24 @@ sdbusplus::message::object_path
             convertCreateParametersToString(CreateParameters::Password));
     if (iter == params.end())
     {
-        log<level::ERR>("Required argument password is missing");
-        elog<InvalidArgument>(Argument::ARGUMENT_NAME("PASSOWORD"),
-                              Argument::ARGUMENT_VALUE("MISSING"));
+        log<level::INFO>("Password is not provide for resource dump");
     }
-
-    try
+    else
     {
-        pwd = std::get<std::string>(iter->second);
-    }
-    catch (const std::bad_variant_access& e)
-    {
-        // Exception will be raised if the input is not string
-        log<level::ERR>("An invalid  password string is passed",
-                        entry("ERROR_MSG=%s", e.what()));
-        elog<InvalidArgument>(Argument::ARGUMENT_NAME("PASSWORD"),
-                              Argument::ARGUMENT_VALUE("INVALID INPUT"));
+        try
+        {
+            pwd = std::get<std::string>(iter->second);
+        }
+        catch (const std::bad_variant_access& e)
+        {
+            // Exception will be raised if the input is not string
+            log<level::ERR>(
+                fmt::format("An invalid password string is passed errormsg({})",
+                            e.what())
+                    .c_str());
+            elog<InvalidArgument>(Argument::ARGUMENT_NAME("PASSWORD"),
+                                  Argument::ARGUMENT_VALUE("INVALID INPUT"));
+        }
     }
 
     std::string generatorId;

--- a/dump-extensions/openpower-dumps/op_dump_util.cpp
+++ b/dump-extensions/openpower-dumps/op_dump_util.cpp
@@ -17,6 +17,9 @@ namespace dump
 {
 namespace util
 {
+
+constexpr auto MP_REBOOT_FILE = "/run/openbmc/mpreboot@0";
+
 using namespace phosphor::logging;
 using InternalFailure =
     sdbusplus::xyz::openbmc_project::Common::Error::InternalFailure;
@@ -60,6 +63,11 @@ void isOPDumpsEnabled()
         elog<disabled>();
     }
     log<level::INFO>("OpenPOWER dumps are enabled");
+}
+
+bool isInMpReboot()
+{
+    return std::filesystem::exists(MP_REBOOT_FILE);
 }
 
 } // namespace util

--- a/dump-extensions/openpower-dumps/op_dump_util.hpp
+++ b/dump-extensions/openpower-dumps/op_dump_util.hpp
@@ -17,6 +17,12 @@ namespace util
  */
 void isOPDumpsEnabled();
 
+/** @brief Check whether memory preserving reboot is in progress
+ *  @return true - memory preserving reboot in progress
+ *          false - no memory preserving reboot is going on
+ */
+bool isInMpReboot();
+
 } // namespace util
 } // namespace dump
 } // namespace openpower

--- a/dump-extensions/openpower-dumps/system_dump_entry.cpp
+++ b/dump-extensions/openpower-dumps/system_dump_entry.cpp
@@ -3,6 +3,7 @@
 #include "dump_utils.hpp"
 #include "host_transport_exts.hpp"
 #include "op_dump_consts.hpp"
+#include "op_dump_util.hpp"
 #include "system_dump_serialize.hpp"
 
 #include <fmt/core.h>
@@ -26,7 +27,7 @@ void Entry::initiateOffload(std::string uri)
 {
     log<level::INFO>(
         fmt::format(
-            "System dump offload request id({}) uri({}) source dumpid()", id,
+            "System dump offload request id({}) uri({}) source dumpid({})", id,
             uri, sourceDumpId())
             .c_str());
     phosphor::dump::Entry::initiateOffload(uri);
@@ -35,15 +36,27 @@ void Entry::initiateOffload(std::string uri)
 
 void Entry::delete_()
 {
-    auto srcDumpID = sourceDumpId();
     auto dumpId = id;
+    // Skip the system dump delete if the dump is in progress
+    // and in memory preserving reboot path
+    if ((openpower::dump::util::isInMpReboot()) &&
+        (status() == phosphor::dump::OperationStatus::InProgress))
+    {
+        log<level::INFO>(
+            fmt::format(
+                "Skip deleting system dump delete id({}) durng mp reboot",
+                dumpId)
+                .c_str());
+        return;
+    }
+
+    auto srcDumpID = sourceDumpId();
+    log<level::INFO>(fmt::format("System dump delete id({}) srcdumpid({})",
+                                 dumpId, srcDumpID)
+                         .c_str());
+
     auto path =
         std::filesystem::path(SYSTEM_DUMP_SERIAL_PATH) / std::to_string(dumpId);
-    log<level::INFO>(
-        fmt::format(
-            "System dump delete id({}) srcdumpid({}) and serial path({})",
-            dumpId, srcDumpID, path.string().c_str())
-            .c_str());
 
     // Remove Dump entry D-bus object
     phosphor::dump::Entry::delete_();


### PR DESCRIPTION
https://gerrit.openbmc-project.xyz/c/openbmc/phosphor-debug-collector/+/51797 Do not remove InProgress system dump entry during mp reboot

 https://gerrit.openbmc-project.xyz/c/openbmc/phosphor-debug-collector/+/51805 Password is not mandatory for resource dump 