### PR TITLE
Fix network and timedate plugin failures during BMC dump generation

### DIFF
--- a/tools/dreport.d/plugins.d/network
+++ b/tools/dreport.d/plugins.d/network
@@ -4,7 +4,7 @@
 # @brief: Collect network information
 #
 
-#. $DREPORT_INCLUDE/functions
+. $DREPORT_INCLUDE/functions
 
 file_name="network.log"
 

--- a/tools/dreport.d/plugins.d/timedate
+++ b/tools/dreport.d/plugins.d/timedate
@@ -9,7 +9,7 @@
 file_name="timedate.log"
 
 timedatectl="/usr/bin/timedatectl"
-if [ -f $timedatectl]; then
+if [ -f $timedatectl ]; then
     add_cmd_output "echo $'\n[timedatectl]'" "$file_name" "timedatectl"
     add_cmd_output "$timedatectl" "$file_name" "timedatectl"
 fi


### PR DESCRIPTION
1) Due to some script errors network and timedate plugins
are failing during BMC dump generation fixed the same.

Failures:
/usr/share/dreport.d/pl_user.d/E30network: line 12: add_cmd_output: command not
found
/usr/share/dreport.d/pl_user.d/E30timedate: line 12: [: missing `]'

Tested:
timedate.log
timedatectl]
               Local time: Mon 2022-04-11 12:41:19 UTC
           Universal time: Mon 2022-04-11 12:41:19 UTC
                 RTC time: Mon 2022-04-11 12:41:19
                Time zone: UTC (UTC, +0000)
System clock synchronized: no
              NTP service: active
          RTC in local TZ: no

network.log
[netstat]
Kernel IP routing table
Destination     Gateway         Genmask         Flags   MSS Window  irtt Iface
0.0.0.0         9.3.23.1        0.0.0.0         UG        0 0          0 eth1
0.0.0.0         9.3.23.1        0.0.0.0         UG        0 0          0 eth0
9.3.23.0        0.0.0.0         255.255.255.0   U         0 0          0 eth0

[eth0]
[Match]
Name=eth0

Signed-off-by: Marri Devender Rao <devenrao@in.ibm.com>