### PR TITLE
Add VPD and Inventory persistent data to BMC dump

### DIFF
--- a/tools/dreport.d/openpower.d/plugins.d/vpd_data
+++ b/tools/dreport.d/openpower.d/plugins.d/vpd_data
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+#
+# config: 23 25
+# @brief: Collect VPD persistent data
+#
+
+. $DREPORT_INCLUDE/functions
+
+vpddir="/var/lib/vpd"
+if [ -d "$vpddir" ]; then
+    add_copy_file "$vpddir" "vpd data"
+fi

--- a/tools/dreport.d/plugins.d/inventorydata
+++ b/tools/dreport.d/plugins.d/inventorydata
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+#
+# config: 23 50
+# @brief: Collect inventory persistent data
+#
+
+. $DREPORT_INCLUDE/functions
+
+inventorydir="/var/lib/phosphor-inventory-manager"
+if [ -d "$inventorydir" ]; then
+    add_copy_file "$inventorydir" "Inventory data"
+fi


### PR DESCRIPTION
1. Add /var/lib/vpd data to BMC dump

Signed-off-by: Marri Devender Rao <devenrao@in.ibm.com>
Change-Id: Ida18ffece04aaf2e604077f39752bee3bae98469