### PR TITLE
Dump Offload: Increase select() timeout

### DIFF
--- a/dump_offload.cpp
+++ b/dump_offload.cpp
@@ -153,7 +153,7 @@ void requestOffload(std::filesystem::path file, uint32_t dumpId,
 
         fd_set readFD;
         struct timeval timeVal;
-        timeVal.tv_sec = 1;
+        timeVal.tv_sec = 5;
         timeVal.tv_usec = 0;
 
         FD_ZERO(&readFD);


### PR DESCRIPTION
Currently one sec timeout for select() call may not be enough
Intermittently noticed that when bmcweb busy with too many
D-bus operations, socket operations from bmcweb may be delayed.

To address this issue, increasing select() timeout to 5 seconds.

This PR fixes https://w3.rchland.ibm.com/projects/bestquest/?verb=view&defect=SW547774


Tested by:
Few iterations of BMC dump offload