### PR TITLE
use templated object for sdbusplus emit

### DIFF
--- a/dump-extensions/openpower-dumps/host_dump_entry.hpp
+++ b/dump-extensions/openpower-dumps/host_dump_entry.hpp
@@ -51,7 +51,8 @@ class Entry :
           const std::filesystem::path& file,
           phosphor::dump::OperationStatus status,
           phosphor::dump::Manager& parent) :
-        EntryIfaces<T>(bus, objPath.c_str(), EntryIfaces::action::defer_emit),
+        EntryIfaces<T>(bus, objPath.c_str(),
+                       EntryIfaces<T>::action::defer_emit),
         phosphor::dump::bmc_stored::Entry(bus, objPath.c_str(), dumpId,
                                           timeStamp, fileSize, file, status,
                                           parent)


### PR DESCRIPTION
Without this change we get a compile error

Signed-off-by: Andrew Geissler <geissonator@yahoo.com>