### PR TITLE
Remove duplicate name request

### DIFF
--- a/bmcstored_dump_entry.cpp
+++ b/bmcstored_dump_entry.cpp
@@ -26,8 +26,7 @@ void Entry::delete_()
         log<level::ERR>(
             fmt::format("Dump offload is in progress, cannot delete id({})", id)
                 .c_str());
-        elog<NotAllowed>(
-            Reason("Dump offload is in progress, please try later"));
+        elog<sdbusplus::xyz::openbmc_project::Common::Error::Unavailable>();
     }
 
     // Delete Dump file from Permanent location

--- a/dump-extensions/openpower-dumps/resource_dump_entry.cpp
+++ b/dump-extensions/openpower-dumps/resource_dump_entry.cpp
@@ -68,9 +68,7 @@ void Entry::delete_()
                                     "dump, id({}) srcdumpid({})",
                                     dumpId, srcDumpID)
                             .c_str());
-        elog<sdbusplus::xyz::openbmc_project::Common::Error::NotAllowed>(
-            xyz::openbmc_project::Common::NotAllowed::REASON(
-                "Dump offload is progress"));
+        elog<sdbusplus::xyz::openbmc_project::Common::Error::Unavailable>();
     }
 
     auto path = std::filesystem::path(RESOURCE_DUMP_SERIAL_PATH) /

--- a/dump-extensions/openpower-dumps/system_dump_entry.cpp
+++ b/dump-extensions/openpower-dumps/system_dump_entry.cpp
@@ -58,9 +58,7 @@ void Entry::delete_()
             fmt::format("Dump offload in progress id({}) srcdumpid({})", dumpId,
                         srcDumpID)
                 .c_str());
-        elog<sdbusplus::xyz::openbmc_project::Common::Error::NotAllowed>(
-            xyz::openbmc_project::Common::NotAllowed::REASON(
-                "Dump offload is progress"));
+        elog<sdbusplus::xyz::openbmc_project::Common::Error::Unavailable>();
     }
 
     log<level::INFO>(fmt::format("System dump delete id({}) srcdumpid({})",

--- a/dump_manager_main.cpp
+++ b/dump_manager_main.cpp
@@ -86,8 +86,6 @@ int main()
             dmpMgr->restore();
         }
 
-        bus.request_name(DUMP_BUSNAME);
-
         phosphor::dump::elog::Watch eWatch(bus, mgr);
         bus.attach_event(eventP.get(), SD_EVENT_PRIORITY_NORMAL);
 


### PR DESCRIPTION
There was a duplicate name request in the dump manager
main, may be due to a merge issue.

Signed-off-by: Dhruvaraj Subhashchandran <dhruvaraj@in.ibm.com>