### PR TITLE
Support for human readable timestamp in dump filename

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -147,6 +147,9 @@ conf_data.set('FILENAME_DUMP_ID_POS', get_option('FILENAME_DUMP_ID_POS'),
 conf_data.set('FILENAME_EPOCHTIME_POS', get_option('FILENAME_EPOCHTIME_POS'),
                description : 'Position of timestamp in the dump filename'
              )
+conf_data.set('TIMESTAMP_FORMAT', get_option('TIMESTAMP_FORMAT'),
+               description : 'Timestamp format in filename: 0-epoch 1-human readable'
+             )
 configure_file(configuration : conf_data,
                output : 'config.h'
               )

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -298,3 +298,7 @@ option('FILENAME_EPOCHTIME_POS', type : 'integer',
         value : 3,
         description : 'Position of timestamp in dump filename'
       )
+option('TIMESTAMP_FORMAT', type : 'integer',
+        value : 1,
+        description : 'Timestamp format in filename: 0-epoch 1-human readable'
+      )


### PR DESCRIPTION
Current code is assuming the dump filename is in epoch
but there are cases the timestamp is human readable
format. Add support for such timestamps to convert to
epoch and as the dump time.
Test:
The time is correct now
DICT_ENTRY "sa{sv}" {
                                        STRING "xyz.openbmc_project.Time.EpochTime";
                                        ARRAY "{sv}" {
                                                DICT_ENTRY "sv" {
                                                        STRING "Elapsed";
                                                        VARIANT "t" {
                                                                UINT64 1651592238000000;
                                                        };
                                                };
                                        };

Signed-off-by: Dhruvaraj Subhashchandran <dhruvaraj@in.ibm.com>
Change-Id: Iedbc794f71c09d0a3d515412aa93ed3062302090