### PR TITLE
Fix for returning error during dbus timeout in host stored dumps

### DIFF
--- a/bmcstored_dump_entry.hpp
+++ b/bmcstored_dump_entry.hpp
@@ -98,9 +98,6 @@ class Entry : public phosphor::dump::Entry, public FileIfaces
     }
 
   protected:
-    /** @Dump file name */
-    std::filesystem::path file;
-
     /** @brief sd_event_add_child callback
      *
      *  @param[in] s - event source
@@ -155,6 +152,7 @@ class Entry : public phosphor::dump::Entry, public FileIfaces
     void resetOffloadInProgress()
     {
         offloadInProgress = false;
+        offloadUri(std::string());
     }
 
   private:


### PR DESCRIPTION
53775: Reset the offload URI after offload complete | https://gerrit.openbmc-project.xyz/c/openbmc/phosphor-debug-collector/+/53775

53769: OpenPower: Return unvailable if any error in deleting host dump | https://gerrit.openbmc-project.xyz/c/openbmc/phosphor-debug-collector/+/53769