### PR TITLE
Time elapsed should be in micro seconds

### DIFF
--- a/dump-extensions/openpower-dumps/dump_manager_resource.cpp
+++ b/dump-extensions/openpower-dumps/dump_manager_resource.cpp
@@ -29,8 +29,10 @@ using InternalFailure =
 void Manager::notify(uint32_t dumpId, uint64_t size)
 {
     // Get the timestamp
-    std::time_t timeStamp = std::time(nullptr);
-
+    uint64_t timeStamp =
+        std::chrono::duration_cast<std::chrono::microseconds>(
+            std::chrono::system_clock::now().time_since_epoch())
+            .count();
     // If there is an entry with invalid id update that.
     // If there a completed one with same source id ignore it
     // if there is no invalid id, create new entry

--- a/dump-extensions/openpower-dumps/dump_manager_system.cpp
+++ b/dump-extensions/openpower-dumps/dump_manager_system.cpp
@@ -30,7 +30,10 @@ void Manager::notify(uint32_t dumpId, uint64_t size)
 {
 
     // Get the timestamp
-    std::time_t timeStamp = std::time(nullptr);
+    uint64_t timeStamp =
+        std::chrono::duration_cast<std::chrono::microseconds>(
+            std::chrono::system_clock::now().time_since_epoch())
+            .count();
 
     // System dump can get created due to a fault in server
     // or by request from user. A system dump by fault is

--- a/host-transport-extensions/pldm/common/pldm_utils.cpp
+++ b/host-transport-extensions/pldm/common/pldm_utils.cpp
@@ -38,6 +38,8 @@ int openPLDM()
 uint8_t getPLDMInstanceID(uint8_t eid)
 {
 
+    log<level::INFO>(
+        fmt::format("Get instance id from PLDM eid({})", eid).c_str());
     constexpr auto pldmRequester = "xyz.openbmc_project.PLDM.Requester";
     constexpr auto pldm = "/xyz/openbmc_project/pldm";
 
@@ -52,6 +54,7 @@ uint8_t getPLDMInstanceID(uint8_t eid)
     uint8_t instanceID = 0;
     reply.read(instanceID);
 
+    log<level::INFO>(fmt::format("Got instaceid({})", instanceID).c_str());
     return instanceID;
 }
 


### PR DESCRIPTION
Currently resource and system dumps storing the time in
seconds which is not correct according to D-Bus spec
fixig it

Signed-off-by: Dhruvaraj Subhashchandran <dhruvaraj@in.ibm.com>
Change-Id: Ia789cd51f14a18676f6873625727b22bab14ace4