### PR TITLE
Check for core files and create core dump during startup of dump service

### DIFF
--- a/dump-extensions/openpower-dumps/dump_manager_resource.hpp
+++ b/dump-extensions/openpower-dumps/dump_manager_resource.hpp
@@ -54,6 +54,13 @@ class Manager :
      */
     void restore() override;
 
+    /** @brief Perform any post restore operations after claiming
+     *  the bus name. Any new D-Bus dump objects created will be
+     *  notified to the subscribers.
+     */
+    void checkAndInitialize() override
+    {}
+
     /** @brief Notify the resource dump manager about creation of a new dump.
      *  @param[in] dumpId - Id from the source of the dump.
      *  @param[in] size - Size of the dump.

--- a/dump-extensions/openpower-dumps/dump_manager_system.hpp
+++ b/dump-extensions/openpower-dumps/dump_manager_system.hpp
@@ -53,6 +53,13 @@ class Manager :
      */
     void restore() override;
 
+    /** @brief Perform any post restore operations after claiming
+     *  the bus name. Any new D-Bus dump objects created will be
+     *  notified to the subscribers.
+     */
+    void checkAndInitialize() override
+    {}
+
     /** @brief Notify the system dump manager about creation of a new dump.
      *  @param[in] dumpId - Id from the source of the dump.
      *  @param[in] size - Size of the dump.

--- a/dump_manager.hpp
+++ b/dump_manager.hpp
@@ -62,6 +62,12 @@ class Manager : public Iface
      */
     virtual void restore() = 0;
 
+    /** @brief Perform any post restore operations after claiming
+     *  the bus name. Any new D-Bus dump objects created will be
+     *  notified to the subscribers.
+     */
+    virtual void checkAndInitialize() = 0;
+
   protected:
     /** @brief Erase specified entry d-bus object
      *

--- a/dump_manager_bmc.hpp
+++ b/dump_manager_bmc.hpp
@@ -110,6 +110,12 @@ class Manager :
                      const std::filesystem::path& file,
                      phosphor::dump::OperationStatus status) override;
 
+    /** @brief Perform any post restore operations after claiming
+     *  the bus name. Any new D-Bus dump objects created will be
+     *  notified to the subscribers.
+     */
+    void checkAndInitialize() override;
+
   private:
     /**  @brief Capture BMC Dump based on the Dump type.
      *  @param[in] type - Type of the Dump.
@@ -118,8 +124,11 @@ class Manager :
      *  @return id - The Dump entry id number.
      */
     uint32_t captureDump(Type type, const std::vector<std::string>& fullPaths);
-};
 
+    /** @brief Check if any core files present and create BMC core dump
+     */
+    void checkAndCreateCoreDump();
+};
 } // namespace bmc
 } // namespace dump
 } // namespace phosphor

--- a/dump_manager_bmcstored.hpp
+++ b/dump_manager_bmcstored.hpp
@@ -97,6 +97,13 @@ class Manager : public phosphor::dump::Manager
      */
     void restore() override;
 
+    /** @brief Perform any post restore operations after claiming
+     *  the bus name. Any new D-Bus dump objects created will be
+     *  notified to the subscribers.
+     */
+    void checkAndInitialize() override
+    {}
+
     /** @brief sdbusplus Dump event loop */
     EventPtr eventLoop;
 

--- a/dump_manager_main.cpp
+++ b/dump_manager_main.cpp
@@ -92,6 +92,12 @@ int main()
         // Daemon is all set up so claim the busname now.
         bus.request_name(DUMP_BUSNAME);
 
+        // check and initialize
+        for (auto& dmpMgr : dumpMgrList)
+        {
+            dmpMgr->checkAndInitialize();
+        }
+
         auto rc = sd_event_loop(eventP.get());
         if (rc < 0)
         {


### PR DESCRIPTION
If dump manager crashes core file will be generated but core dump
will not be created as the dump service that creates core dump
is taking a reset.

Now modified to check for core files at the start of the dump service
and capture them in core dump.

https://gerrit.openbmc.org/c/openbmc/phosphor-debug-collector/+/54041

CQ:SW551555