### PR TITLE
opdreport: Adding dump identifier

### DIFF
--- a/tools/dreport.d/ibm.d/gendumpheader
+++ b/tools/dreport.d/ibm.d/gendumpheader
@@ -73,10 +73,22 @@ function dump_size () {
 
 #Function to set dump id to 8 bytes format
 function get_dump_id () {
-    x=${#dump_id}
-    nulltoadd=`expr $SIZE_8 - $x`
-    printf '%*s' "$nulltoadd" | tr ' ' "0" >> "$FILE"
-    printf "%s" "$dump_id" >> "$FILE"
+    # shellcheck disable=SC2154
+    size=${#dump_id}
+    if [ "$1" == "$OP_DUMP" ]; then
+        msize=$(( size / 2 ))
+        nulltoadd=$(( SIZE_4 - msize ))
+        add_null "$nulltoadd"
+        for ((i=0;i<size;i+=2));
+        do
+            # shellcheck disable=SC2059
+            printf "\\x${dump_id:$i:2}" >> "$FILE"
+        done
+    else
+        nulltoadd=$(( SIZE_8 - size ))
+        printf '%*s' "$nulltoadd" | tr ' ' "0" >> "$FILE"
+        printf "%s" "$dump_id" >> "$FILE"
+    fi
 }
 
 #Function to get the bmc serial number
@@ -441,7 +453,7 @@ function mainstore_dump_section () {
 function plat_dump_header () {
     printf "SYS DUMP" >> "$FILE"
     dump_time
-    add_null 4   #Dump identifier
+    get_dump_id "$OP_DUMP"   #Dump identifier
     printf '\x02' >> "$FILE"
     printf '\x21' >> "$FILE" #Need to cross check
     printf '\x04' >> "$FILE" #Dump header size 0x0400


### PR DESCRIPTION
Change:
-Populating dump identifier in dump header.

Tested:
Post change can see the dump identifier in dump header.

Signed-off-by: Chirag Sharma <chirshar@in.ibm.com>
Change-Id: Idcb1b2c20633ccdd9bb2b3cd763b39cbf945c91f

Gerrit link:- https://gerrit.openbmc.org/c/openbmc/phosphor-debug-collector/+/54152