### PR TITLE
openpower:dreport - invalid guard data catpured in guard file

### DIFF
--- a/tools/dreport.d/openpower.d/plugins.d/guardlist
+++ b/tools/dreport.d/openpower.d/plugins.d/guardlist
@@ -4,7 +4,10 @@
 # @brief: Collect GUARD record information.
 #
 
+# shellcheck disable=SC1091
 . "$DREPORT_INCLUDE/functions"
+
+source /etc/profile.d/power-target.sh
 
 desc="GUARD partition"
 guard_part_file="/var/lib/phosphor-software-manager/hostfw/running/GUARD"


### PR DESCRIPTION
As the PDBG_DTB enviroment variable is not set invalid guard
data is captured as part of the guard list command

https://gerrit.openbmc.org/c/openbmc/phosphor-debug-collector/+/54426

---------------<Before>------------------
root@perfrain86bmctest:/tmp/test/BMCDUMP.139F0B0.00000022.20220609102417# cat
guard.log
[Guard list]
ID       | ERROR    |  Type  | Path
00000001 | 00000000 | manual | physical:sys-0/node-0/proc-1

[Guard resolved records]
No resolved records to display

[Guard ephemeral records]
No ephemeral records to display

-------------------<After>-----------
root@xxxx:/tmp/test/BMCDUMP.139F0B0.00000023.20220609110500# cat guard.log
[Guard list]
ID       | ERROR    |  Type  | Path
00000001 | 00000000 | manual | physical:sys-0/node-0/proc-1

[Guard resolved records]
No resolved records to display

[Guard ephemeral records]
No ephemeral records to display

Signed-off-by: Marri Devender Rao <devenrao@in.ibm.com>
Change-Id: Iff65587958e75ee495614eb895168b058e6a4e84