### PR TITLE
openpower:dreport - guard list data not captured properly in BMC dump

### DIFF
--- a/tools/dreport.d/openpower.d/plugins.d/guardlist
+++ b/tools/dreport.d/openpower.d/plugins.d/guardlist
@@ -4,7 +4,10 @@
 # @brief: Collect GUARD record information.
 #
 
+# shellcheck disable=SC1091
 . "$DREPORT_INCLUDE/functions"
+
+source /etc/profile.d/power-target.sh
 
 desc="GUARD partition"
 guard_part_file="/var/lib/phosphor-software-manager/hostfw/running/GUARD"


### PR DESCRIPTION
Guard tool looks for device tree file which is set by enviroment
variable to parse the guard records from the guard partition.

As the device tree location was not found guard tool was writing default
dummy data to the guard file.

https://gerrit.openbmc.org/c/openbmc/phosphor-debug-collector/+/54426

Tested:
[Guard list]
ID | ERROR | Type | Path
00000001 | 00000000 | manual | physical:sys-0/node-0/proc-1

Signed-off-by: Marri Devender Rao <devenrao@in.ibm.com>
Change-Id: I74b1720ce8c7140a59e00d35ac45ac8a7c020e53