### PR TITLE
sdevent - inode entry created during dump generation is not released

### DIFF
--- a/bmcstored_dump_entry.hpp
+++ b/bmcstored_dump_entry.hpp
@@ -11,6 +11,7 @@
 #include <phosphor-logging/log.hpp>
 #include <sdbusplus/bus.hpp>
 #include <sdbusplus/server/object.hpp>
+#include <sdeventplus/source/child.hpp>
 
 #include <filesystem>
 
@@ -26,6 +27,7 @@ template <typename T>
 using ServerObject = typename sdbusplus::server::object::object<T>;
 using FileIfaces = sdbusplus::server::object::object<
     sdbusplus::xyz::openbmc_project::Common::server::FilePath>;
+using ::sdeventplus::source::Child;
 
 class Manager;
 
@@ -98,39 +100,6 @@ class Entry : public phosphor::dump::Entry, public FileIfaces
     }
 
   protected:
-    /** @brief sd_event_add_child callback
-     *
-     *  @param[in] s - event source
-     *  @param[in] si - signal info
-     *  @param[in] entry - pointer to dump entry
-     *
-     *  @returns 0 on success, -1 on fail
-     */
-    static int callback(sd_event_source*, const siginfo_t* si, void* entry)
-    {
-        if (entry != NULL)
-        {
-            phosphor::dump::bmc_stored::Entry* dumpEntry =
-                reinterpret_cast<phosphor::dump::bmc_stored::Entry*>(entry);
-            dumpEntry->resetOffloadInProgress();
-            if (si->si_status == 0)
-            {
-                dumpEntry->offloaded(true);
-                log<level::ERR>(fmt::format("Dump offload completed id({})",
-                                            dumpEntry->getDumpId())
-                                    .c_str());
-            }
-            else
-            {
-                log<level::ERR>(fmt::format("Dump offload failed id({})",
-                                            dumpEntry->getDumpId())
-                                    .c_str());
-            }
-        }
-
-        return 0;
-    }
-
     /** @brief Check whether offload is in progress
      *  @return true if offloading in progress
      *          false if offloading in not progress
@@ -159,6 +128,9 @@ class Entry : public phosphor::dump::Entry, public FileIfaces
     /** @brief Indicates whether offload in progress
      */
     bool offloadInProgress;
+
+    /** @brief map of SDEventPlus child pointer added to event loop */
+    std::unique_ptr<Child> childPtr;
 };
 
 } // namespace bmc_stored

--- a/dump_manager_bmc.hpp
+++ b/dump_manager_bmc.hpp
@@ -5,9 +5,11 @@
 #include "watch.hpp"
 #include "xyz/openbmc_project/Dump/Internal/Create/server.hpp"
 
+#include <sdeventplus/source/child.hpp>
 #include <xyz/openbmc_project/Dump/Create/server.hpp>
 
 #include <filesystem>
+#include <map>
 
 namespace phosphor
 {
@@ -27,6 +29,8 @@ using CreateIface = sdbusplus::server::object::object<
 
 using Type =
     sdbusplus::xyz::openbmc_project::Dump::Internal::server::Create::Type;
+
+using ::sdeventplus::source::Child;
 
 // Type to dreport type  string map
 static const std::map<Type, std::string> TypeMap = {
@@ -128,6 +132,9 @@ class Manager :
     /** @brief Check if any core files present and create BMC core dump
      */
     void checkAndCreateCoreDump();
+
+    /** @brief SDEventPlus child pointer added to event loop */
+    std::map<pid_t, std::unique_ptr<Child>> childPtrMap;
 };
 } // namespace bmc
 } // namespace dump

--- a/dump_manager_bmcstored.hpp
+++ b/dump_manager_bmcstored.hpp
@@ -108,33 +108,6 @@ class Manager : public phosphor::dump::Manager
     EventPtr eventLoop;
 
   protected:
-    /** @brief sd_event_add_child callback
-     *
-     *  @param[in] s - event source
-     *  @param[in] si - signal info
-     *  @param[in] userdata - pointer to Watch object
-     *
-     *  @returns 0 on success, -1 on fail
-     */
-    static int callback(sd_event_source*, const siginfo_t* si, void* entry)
-    {
-        // Set progress as failed if packaging return error
-        if (si->si_status != 0)
-        {
-            log<level::ERR>("Dump packaging failed");
-            if (entry != NULL)
-            {
-                reinterpret_cast<phosphor::dump::Entry*>(entry)->status(
-                    phosphor::dump::OperationStatus::Failed);
-            }
-        }
-        else
-        {
-            log<level::INFO>("Dump packaging completed");
-        }
-        return 0;
-    }
-
     /** @brief Calculate per dump allowed size based on the available
      *        size in the dump location.
      *  @returns dump size in kilobytes.

--- a/meson.build
+++ b/meson.build
@@ -36,6 +36,7 @@ else
         'sdbuspp_gen_meson_prog'
     )
 endif
+sdeventplus_dep = dependency('sdeventplus')
 phosphor_dbus_interfaces_dep = dependency(
     'phosphor-dbus-interfaces',
     fallback: [
@@ -194,6 +195,7 @@ phosphor_dump_manager_sources = [
 phosphor_dump_manager_dependency = [
         phosphor_dbus_interfaces_dep,
         sdbusplus_dep,
+        sdeventplus_dep,
         phosphor_logging_dep,
         fmt_dep,
         cereal_dep,

--- a/subprojects/sdeventplus.wrap
+++ b/subprojects/sdeventplus.wrap
@@ -1,0 +1,6 @@
+[wrap-git]
+url = https://github.com/openbmc/sdeventplus.git
+revision = HEAD
+
+[provide]
+sdeventplus = sdeventplus_dep


### PR DESCRIPTION
For every dump generated an "anon_inode:[pidfd]" entry is created for the associated process and the same is not released. When the number of inode entries reach the maximum count dump request will fail and the dump service takes a reset with a core dump.

When a dump is requested a child process is spawned to perform dump collection. Parent process waits on the child process completion using sd-event-add-child systemd call. sd-event-add-child adds an inode entry which needs to be released during the callback method called after child process exit using unref but the same is not done.

Now switching to sdeventplus::source::Child wrapper class for sd-event-add-child which takes care of releasing the inode fd.

Tested:
Without the fix for the 3 dumps created noticed 3 anon_inode:[pidfd]
are added but not cleared
root@rain135bmc:/proc/2044/fd# ls -la
dr-x------    2 root     root             0 Jun 27 08:38 .
dr-xr-xr-x    8 root     root             0 Jun 27 08:38 ..
lr-x------    1 root     root            64 Jun 27 08:39 0 -> /dev/null
lrwx------    1 root     root            64 Jun 27 08:39 1 -> socket:[21586]
lrwx------    1 root     root            64 Jun 27 08:39 10
->anon_inode:[timerfd]
lrwx------    1 root     root            64 Jun 27 08:47 11 ->anon_inode:[pidfd]
lrwx------    1 root     root            64 Jun 27 08:47 12 ->anon_inode:[pidfd]
lrwx------    1 root     root            64 Jun 27 08:47 13 ->anon_inode:[pidfd]

After the fix noticed all the anon_inode:[pidfd] are cleared
dr-x------    2 root     root             0 Jun 27 08:38 .
dr-xr-xr-x    8 root     root             0 Jun 27 08:38 ..
lr-x------    1 root     root            64 Jun 27 08:39 0 -> /dev/null
lrwx------    1 root     root            64 Jun 27 08:39 1 -> socket:[21586]
lrwx------    1 root     root            64 Jun 27 08:39 10
->anon_inode:[timerfd]

Change-Id: I57fa9deb2d5265c9d510e24a713f60c6ae847f15
Signed-off-by: Marri Devender Rao <devenrao@in.ibm.com>