### PR TITLE
dreport: Add entity-manager's system.json to dump

### DIFF
--- a/tools/dreport.d/plugins.d/emconfig
+++ b/tools/dreport.d/plugins.d/emconfig
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+#
+# config: 2 20
+# @brief: Save the entity manager configuration
+#
+
+. $DREPORT_INCLUDE/functions
+
+desc="entity-manager configuration"
+file_name="em-system.json"
+
+if [ -e "/var/configuration/system.json" ]; then
+  command="cat /var/configuration/system.json"
+  add_cmd_output "$command" "$file_name" "$desc"
+fi


### PR DESCRIPTION
Add /var/configuration/system.json to BMC dumps as em-system.json.  This
file contains a JSON representation of the objects that entity-manager
puts on D-Bus and can be used to debug problems when entity-manager
crashes.

Tested:

~/dumps/BMCDUMP.13BE960.00000000.20220802172737_out/archive$ ls -l em-system.json
-rw-r--r--. 1 spinler spinler 10688 Aug  2 12:27 em-system.json

Signed-off-by: Matt Spinler <spinler@us.ibm.com>
Change-Id: Icc4e38e9594b578b83b65a23af8da67e514572c2