### PR TITLE
dreport: Add phosphor-fan-monitor data to dump

### DIFF
--- a/tools/dreport.d/plugins.d/fanmondump
+++ b/tools/dreport.d/plugins.d/fanmondump
@@ -1,0 +1,31 @@
+#!/bin/bash
+#
+# config: 2 20
+# @brief: Get the fan monitor dump
+#
+
+. $DREPORT_INCLUDE/functions
+
+if [ ! -e "/usr/bin/phosphor-fan-monitor" ]; then
+  exit 0
+fi
+
+file_name="/tmp/fan_monitor_dump.json"
+
+rm -f $file_name
+killall -s SIGUSR1 phosphor-fan-monitor
+
+seconds=0
+while [ ! -e "$file_name" ]; do
+    seconds=$(( seconds + 1 ))
+    if [ $seconds -eq 5 ]; then
+        echo "Timed out waiting for fan monitor dump"
+        exit 0
+    fi
+    sleep 1
+done
+
+desc="fan monitor dump"
+add_copy_file "$file_name" "$desc"
+
+rm -rf /tmp/fan_monitor_dump.json


### PR DESCRIPTION
Send the USR1 signal to phosphor-fan-monitor to collect its dump data as part of a BMC dump.

Tested:

~/BMCDUMP.139F210.00000041.20220908143628_out/archive$ cat fan_monitor_dump.json {
    "logs": [],
    "sensors": {
        "sensors": {
            "/xyz/openbmc_project/sensors/fan_tach/fan0_0": {
                "functional": true,
                "in_range": true,
                "present": true,
                "prev_tachs": "[11904,11867,11904,11904,11867,11904,11867,11904]",
                "prev_targets": "[18000,0,0,0,0,0,0,0]",
                "tach": 11904.0,
                "target": 18000,
                "ticks": 0
            },
     ...
}

Signed-off-by: Matt Spinler <spinler@us.ibm.com>
Change-Id: I1173a38a755edff14ee0d418ec29ac0c583a790f