### PR TITLE
dreport: Add audit.log Data to Dump

### DIFF
--- a/tools/dreport.d/plugins.d/auditlog
+++ b/tools/dreport.d/plugins.d/auditlog
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+#
+# config: 2 40
+# @brief: Save the audit log
+#
+
+. $DREPORT_INCLUDE/functions
+
+desc="Audit Log"
+file_name="audit-log.log"
+
+if [ -e "/var/log/audit/audit.log" ]; then
+  add_copy_file "$file_name" "$desc"
+fi


### PR DESCRIPTION
Add /var/log/audit/audit.log to BMC dumps as audit-log.log. This file contains a log of the events that occurred and who initiated them.

Tested:
~/Code/dumps/2/BMCDUMP.SIMP10R.00000002.20220919155900_out/archive$ ls -la audit-log.log 
 -rw-r--r-- 1 zamiseck zamiseck 3993 Sep 19 10:59 audit-log.log