### PR TITLE
opdreport : fix driver as unknown error when parsing scs dump header

### DIFF
--- a/tools/dreport.d/ibm.d/gendumpheader
+++ b/tools/dreport.d/ibm.d/gendumpheader
@@ -76,8 +76,7 @@ function get_dump_id () {
     # shellcheck disable=SC2154
     size=${#dump_id}
     if [ "$1" == "$OP_DUMP" ]; then
-        msize=$(( size / 2 ))
-        nulltoadd=$(( SIZE_4 - msize ))
+        nulltoadd=$(( SIZE_4 - size / 2 - size % 2 ))
         add_null "$nulltoadd"
         for ((i=0;i<size;i+=2));
         do


### PR DESCRIPTION
    opdreport : fix driver as unknown error when parsing scs dump header
    
    The get_dump_id function has been modified to handle the odd dump ID size so
    that id doesn't add any extra byte
    
    The Problem:
    
    00000020  31 33 39 46 32 33 30 2e  30 30 30 30 30 30 30 31  |139F230.00000001| <-------Dump ID is 1 which is the entry ID as well
    000000e0  00 00 00 00 01 02 21 04  00 00 00 00 00 00 63 96  |......!.......c.| <--------Dump ID comes as 00 00 00 00 01 which is same as previous with an extra byte added
    
    The solution:
    
    00000020  31 33 39 46 32 33 30 2e  30 30 30 30 30 30 30 39  |139F230.00000009| <-------Dump ID is 9 which is the entry ID as well
    000000e0  00 00 00 09 02 21 04 00  00 00 00 00 00 63 8d 02  |.....!.......c..| <--------Dump ID comes as 00 00 00 09 which is correct 4 bytes value without an extra byte added
    
    Tested:
    
    Post changed for any dump ID the values are coming as expected without any extra
    byte added
    
    Signed-off-by: Swarnendu Roy Chowdhury <swarnendu.roy.chowdhury@ibm.com>
    Change-Id: Ibe7c42d30fb125dbd4b3d4d334614756f6bc948b