### PR TITLE
OpenPOWER: Add PCIInit also as host running state

### DIFF
--- a/dump_utils.cpp
+++ b/dump_utils.cpp
@@ -131,7 +131,8 @@ bool isHostRunning()
     if ((bootProgressStatus == BootProgress::SystemInitComplete) ||
         (bootProgressStatus == BootProgress::SystemSetup) ||
         (bootProgressStatus == BootProgress::OSStart) ||
-        (bootProgressStatus == BootProgress::OSRunning))
+        (bootProgressStatus == BootProgress::OSRunning) ||
+        (bootProgressStatus == BootProgress::PCIInit))
     {
         return true;
     }


### PR DESCRIPTION
PCI init starts once the host is started and the resource dump or system dump can be initiated at this stage. There are usecase where host is stuck at this stage so collecting a system dump or resource dump is critical for the debug.

Test: Set the state and initiated the resource dump

Signed-off-by: Dhruvaraj Subhashchandran <dhruvaraj@in.ibm.com>
Change-Id: I8ba7246fe84c146c104644b18507cd217db42d18