### PR TITLE
Phosphor dump manager : Crashed for quota exceeded error

### DIFF
--- a/dump_manager_bmc.cpp
+++ b/dump_manager_bmc.cpp
@@ -177,7 +177,18 @@ void Manager::checkAndCreateCoreDump()
             log<level::INFO>(
                 fmt::format("Core file found, files size {}", files.size())
                     .c_str());
-            captureDump(Type::ApplicationCored, files);
+            try
+            {
+                captureDump(Type::ApplicationCored, files);
+            }
+            catch (const std::exception& excp)
+            {
+                log<level::ERR>(
+                    fmt::format("Exception received while capturing dump: "
+                                "{}",
+                                excp.what())
+                        .c_str());
+            }
         }
     }
 }

--- a/tools/dreport.d/ibm.d/gendumpheader
+++ b/tools/dreport.d/ibm.d/gendumpheader
@@ -76,8 +76,7 @@ function get_dump_id () {
     # shellcheck disable=SC2154
     size=${#dump_id}
     if [ "$1" == "$OP_DUMP" ]; then
-        msize=$(( size / 2 ))
-        nulltoadd=$(( SIZE_4 - msize ))
+        nulltoadd=$(( SIZE_4 - size / 2 - size % 2 ))
         add_null "$nulltoadd"
         for ((i=0;i<size;i+=2));
         do


### PR DESCRIPTION
Phosphor-dump-manager : Handled quota exceeded exception

BMC goes into Quiesced state due to the crashing of Phosphor Dump manager for
not being able to handle the exception thrown while capturing core dumps if the
disk quota is full