### PR TITLE
openpower:dreport: Save badPEL file in dump

### DIFF
--- a/tools/dreport.d/ibm.d/plugins.d/badpel
+++ b/tools/dreport.d/ibm.d/plugins.d/badpel
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+#
+# config: 2 20
+# @brief: Save the 'badPEL' file
+#
+
+. $DREPORT_INCLUDE/functions
+
+desc="Bad PEL file"
+file_name="/var/lib/phosphor-logging/extensions/pels/badPEL"
+
+if [ -e "$file_name" ]; then
+  add_copy_file "$file_name" "$desc"
+fi


### PR DESCRIPTION
The last invalid/corrupt PEL the host sent down to the BMC is saved in /var/lib/phosphor-logging/extensions/pels/badPEL.  Save it in a dump if it exists so we can get the contents when it happens in the field.

Tested:
~/BMCDUMP.SIMP10R.00000000.20221012205429_out/archive$ ls -l badPEL -rw-r--r--. 1 spinler spinler 5599 Oct 12 15:54 badPEL

Signed-off-by: Matt Spinler <spinler@us.ibm.com>
Change-Id: Id6052d5c4c052860e978314e541d4a1b978ee615