### PR TITLE
dreport: Change audit.log Data

### DIFF
--- a/tools/dreport.d/plugins.d/auditlog
+++ b/tools/dreport.d/plugins.d/auditlog
@@ -7,8 +7,8 @@
 . $DREPORT_INCLUDE/functions
 
 desc="Audit Log"
-file_name="audit-log.log"
+file_name="/var/log/audit/audit.log"
 
-if [ -e "/var/log/audit/audit.log" ]; then
+if [ -e "$file_name" ]; then
   add_copy_file "$file_name" "$desc"
 fi


### PR DESCRIPTION
The file name of the audit log data changed from audit-log.log to audit.log. Need to alter dump collection to reflect that.

TESTED:
ls -la BMCDUMP.SIMP10R.00000005.20221109204326_out/archive/audit.log -rw------- 1 zamiseck zamiseck 17984 Nov  9 14:45
BMCDUMP.SIMP10R.00000005.20221109204326_out/archive/audit.log