### PR TITLE
Implement OriginatedBy interface in dump entry dbus obj

### DIFF
--- a/bmc_dump_entry.hpp
+++ b/bmc_dump_entry.hpp
@@ -18,6 +18,9 @@ namespace bmc
 template <typename T>
 using ServerObject = typename sdbusplus::server::object::object<T>;
 
+using originatorTypes = sdbusplus::xyz::openbmc_project::Common::server::
+    OriginatedBy::OriginatorTypes;
+
 using EntryIfaces = sdbusplus::server::object::object<
     sdbusplus::xyz::openbmc_project::Common::server::GeneratedBy,
     sdbusplus::xyz::openbmc_project::Dump::Entry::server::BMC>;
@@ -50,19 +53,23 @@ class Entry :
      *  @param[in] fileSize - Dump file size in bytes.
      *  @param[in] file - Name of dump file.
      *  @param[in] status - status of the dump.
+     *  @param[in] originatorId - Id of the originator of the dump.
+     *  @param[in] originatorType - Originator type.
      *  @param[in] parent - The dump entry's parent.
      */
     Entry(sdbusplus::bus::bus& bus, const std::string& objPath, uint32_t dumpId,
           uint64_t timeStamp, uint64_t fileSize,
           const std::filesystem::path& file, std::string genId,
-          phosphor::dump::OperationStatus status,
-          phosphor::dump::Manager& parent) :
+          phosphor::dump::OperationStatus status, std::string origId,
+          originatorTypes origType, phosphor::dump::Manager& parent) :
         EntryIfaces(bus, objPath.c_str(), EntryIfaces::action::defer_emit),
         phosphor::dump::bmc_stored::Entry(bus, objPath.c_str(), dumpId,
                                           timeStamp, fileSize, file, status,
                                           parent)
     {
         generatorId(genId);
+        originatorId(origId);
+        originatorType(origType);
         // Emit deferred signal.
         this->phosphor::dump::bmc::EntryIfaces::emit_object_added();
     }

--- a/dump-extensions/openpower-dumps/resource_dump_entry.hpp
+++ b/dump-extensions/openpower-dumps/resource_dump_entry.hpp
@@ -3,6 +3,7 @@
 #include "com/ibm/Dump/Entry/Resource/server.hpp"
 #include "dump_entry.hpp"
 #include "xyz/openbmc_project/Common/GeneratedBy/server.hpp"
+#include "xyz/openbmc_project/Common/OriginatedBy/server.hpp"
 
 #include <sdbusplus/bus.hpp>
 #include <sdbusplus/server/object.hpp>
@@ -21,6 +22,9 @@ using ServerObject = typename sdbusplus::server::object::object<T>;
 using EntryIfaces = sdbusplus::server::object::object<
     sdbusplus::xyz::openbmc_project::Common::server::GeneratedBy,
     sdbusplus::com::ibm::Dump::Entry::server::Resource>;
+
+using originatorTypes = sdbusplus::xyz::openbmc_project::Common::server::
+    OriginatedBy::OriginatorTypes;
 
 class Manager;
 
@@ -51,6 +55,8 @@ class Entry : virtual public EntryIfaces, virtual public phosphor::dump::Entry
      *  @param[in] vspStr- Input to host to generate the resource dump.
      *  @param[in] pwd - Password needed by host to validate the request.
      *  @param[in] status - status  of the dump.
+     *  @param[in] originatorId - Id of the originator of the dump
+     *  @param[in] originatorType - Originator type
      *  @param[in] baseEntryPath - Base entry path
      *  @param[in] parent - The dump entry's parent.
      *  @param[in] emitSignal - Default true, this to emit the signal for dump
@@ -59,9 +65,9 @@ class Entry : virtual public EntryIfaces, virtual public phosphor::dump::Entry
     Entry(sdbusplus::bus::bus& bus, const std::string& objPath, uint32_t dumpId,
           uint64_t timeStamp, uint64_t dumpSize, const uint32_t sourceId,
           std::string vspStr, std::string pwd, std::string genId,
-          phosphor::dump::OperationStatus status,
-          const std::string& baseEntryPath, phosphor::dump::Manager& parent,
-          bool emitSignal = true) :
+          phosphor::dump::OperationStatus status, std::string originId,
+          originatorTypes originType, const std::string& baseEntryPath,
+          phosphor::dump::Manager& parent, bool emitSignal = true) :
         EntryIfaces(bus, objPath.c_str(), EntryIfaces::action::defer_emit),
         phosphor::dump::Entry(bus, objPath.c_str(), dumpId, timeStamp, dumpSize,
                               status, parent),
@@ -71,6 +77,8 @@ class Entry : virtual public EntryIfaces, virtual public phosphor::dump::Entry
         vspString(vspStr);
         password(pwd);
         generatorId(genId);
+        originatorId(originId);
+        originatorType(originType);
         // Emit deferred signal.
         if (emitSignal)
             this->openpower::dump::resource::EntryIfaces::emit_object_added();

--- a/dump-extensions/openpower-dumps/system_dump_entry.hpp
+++ b/dump-extensions/openpower-dumps/system_dump_entry.hpp
@@ -2,6 +2,7 @@
 
 #include "dump_entry.hpp"
 #include "xyz/openbmc_project/Common/GeneratedBy/server.hpp"
+#include "xyz/openbmc_project/Common/OriginatedBy/server.hpp"
 #include "xyz/openbmc_project/Dump/Entry/System/server.hpp"
 
 #include <sdbusplus/bus.hpp>
@@ -19,6 +20,9 @@ using ServerObject = typename sdbusplus::server::object::object<T>;
 using EntryIfaces = sdbusplus::server::object::object<
     sdbusplus::xyz::openbmc_project::Common::server::GeneratedBy,
     sdbusplus::xyz::openbmc_project::Dump::Entry::server::System>;
+
+using originatorTypes = sdbusplus::xyz::openbmc_project::Common::server::
+    OriginatedBy::OriginatorTypes;
 
 class Manager;
 
@@ -46,12 +50,15 @@ class Entry : virtual public EntryIfaces, virtual public phosphor::dump::Entry
      *  @param[in] dumpSize - Dump size in bytes.
      *  @param[in] sourceId - DumpId provided by the source.
      *  @param[in] status - status  of the dump.
+     *  @param[in] originatorId - Id of the originator of the dump.
+     *  @param[in] originatorType - Originator type.
      *  @param[in] baseEntryPath - Base entry path
      *  @param[in] parent - The dump entry's parent.
      */
     Entry(sdbusplus::bus::bus& bus, const std::string& objPath, uint32_t dumpId,
           uint64_t timeStamp, uint64_t dumpSize, const uint32_t sourceId,
           std::string genId, phosphor::dump::OperationStatus status,
+          std::string originId, originatorTypes originType,
           const std::string& baseEntryPath, phosphor::dump::Manager& parent,
           bool emitsignal = true) :
         EntryIfaces(bus, objPath.c_str(), EntryIfaces::action::defer_emit),
@@ -61,6 +68,8 @@ class Entry : virtual public EntryIfaces, virtual public phosphor::dump::Entry
     {
         sourceDumpId(sourceId);
         generatorId(genId);
+        originatorId(originId);
+        originatorType(originType);
         // Emit deferred signal.
         if (emitsignal)
         {

--- a/dump_entry.hpp
+++ b/dump_entry.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "xyz/openbmc_project/Common/OriginatedBy/server.hpp"
 #include "xyz/openbmc_project/Common/Progress/server.hpp"
 #include "xyz/openbmc_project/Dump/Entry/server.hpp"
 #include "xyz/openbmc_project/Object/Delete/server.hpp"
@@ -23,6 +24,7 @@ using ServerObject = typename sdbusplus::server::object::object<T>;
 // from sdbusplus::xyz::openbmc_project::Common::server::Progress
 // #ibm-openbmc/2809
 using EntryIfaces = sdbusplus::server::object::object<
+    sdbusplus::xyz::openbmc_project::Common::server::OriginatedBy,
     sdbusplus::xyz::openbmc_project::Common::server::Progress,
     sdbusplus::xyz::openbmc_project::Dump::server::Entry,
     sdbusplus::xyz::openbmc_project::Object::server::Delete,
@@ -30,6 +32,9 @@ using EntryIfaces = sdbusplus::server::object::object<
 
 using OperationStatus =
     sdbusplus::xyz::openbmc_project::Common::server::Progress::OperationStatus;
+
+using originatorTypes = sdbusplus::xyz::openbmc_project::Common::server::
+    OriginatedBy::OriginatorTypes;
 
 class Manager;
 

--- a/dump_manager.hpp
+++ b/dump_manager.hpp
@@ -6,6 +6,8 @@
 #include <sdbusplus/bus.hpp>
 #include <sdbusplus/server/object.hpp>
 
+#define CREATE_DUMP_MAX_PARAMS 2
+
 namespace phosphor
 {
 namespace dump

--- a/dump_manager_bmc.hpp
+++ b/dump_manager_bmc.hpp
@@ -97,7 +97,9 @@ class Manager :
                      const uint64_t ms, uint64_t fileSize,
                      const std::filesystem::path& file,
                      const std::string& generatorId,
-                     phosphor::dump::OperationStatus status);
+                     phosphor::dump::OperationStatus status,
+                     const std::string& originatorId,
+                     originatorTypes originatorType);
 
     /** @brief Create a  Dump Entry Object
      *  @param[in] id - Id of the dump

--- a/dump_utils.hpp
+++ b/dump_utils.hpp
@@ -1,11 +1,19 @@
 #pragma once
 
+#include "dump_manager.hpp"
+
+#include <fmt/core.h>
 #include <fmt/format.h>
 #include <systemd/sd-event.h>
 #include <unistd.h>
 
+#include <com/ibm/Dump/Create/server.hpp>
+#include <phosphor-logging/elog-errors.hpp>
+#include <phosphor-logging/elog.hpp>
 #include <phosphor-logging/log.hpp>
 #include <sdbusplus/bus.hpp>
+#include <xyz/openbmc_project/Common/error.hpp>
+#include <xyz/openbmc_project/Dump/Create/server.hpp>
 #include <xyz/openbmc_project/State/Boot/Progress/server.hpp>
 #include <xyz/openbmc_project/State/Host/server.hpp>
 
@@ -20,6 +28,9 @@ using BootProgress = sdbusplus::xyz::openbmc_project::State::Boot::server::
     Progress::ProgressStages;
 using HostState =
     sdbusplus::xyz::openbmc_project::State::server::Host::HostState;
+
+using namespace phosphor::logging;
+using namespace sdbusplus::xyz::openbmc_project::Common::Error;
 
 /* Need a custom deleter for freeing up sd_event */
 struct EventDeleter
@@ -164,6 +175,73 @@ T readDBusProperty(sdbusplus::bus::bus& bus, const std::string& service,
         throw;
     }
     return retVal;
+}
+
+inline void extractOriginatorProperties(phosphor::dump::DumpCreateParams params,
+                                        std::string& originatorId,
+                                        originatorTypes& originatorType)
+{
+    using InvalidArgument =
+        sdbusplus::xyz::openbmc_project::Common::Error::InvalidArgument;
+    using Argument = xyz::openbmc_project::Common::InvalidArgument;
+    using CreateParametersXYZ =
+        sdbusplus::xyz::openbmc_project::Dump::server::Create::CreateParameters;
+
+    auto iter = params.find(
+        sdbusplus::xyz::openbmc_project::Dump::server::Create::
+            convertCreateParametersToString(CreateParametersXYZ::OriginatorId));
+    if (iter == params.end())
+    {
+        log<level::INFO>("OriginatorId is not provided");
+    }
+    else
+    {
+        try
+        {
+            originatorId = std::get<std::string>(iter->second);
+        }
+        catch (const std::bad_variant_access& e)
+        {
+            // Exception will be raised if the input is not string
+            log<level::ERR>(
+                fmt::format(
+                    "An invalid  originatorId passed. It should be a string, "
+                    "errormsg({})",
+                    e.what())
+                    .c_str());
+            elog<InvalidArgument>(Argument::ARGUMENT_NAME("ORIGINATOR_ID"),
+                                  Argument::ARGUMENT_VALUE("INVALID INPUT"));
+        }
+    }
+
+    iter = params.find(sdbusplus::xyz::openbmc_project::Dump::server::Create::
+                           convertCreateParametersToString(
+                               CreateParametersXYZ::OriginatorType));
+    if (iter == params.end())
+    {
+        log<level::INFO>("OriginatorType is not provided. Replacing the string "
+                         "with the default value");
+        originatorType = originatorTypes::Internal;
+    }
+    else
+    {
+        try
+        {
+            std::string type = std::get<std::string>(iter->second);
+            originatorType = sdbusplus::xyz::openbmc_project::Common::server::
+                OriginatedBy::convertOriginatorTypesFromString(type);
+        }
+        catch (const std::bad_variant_access& e)
+        {
+            // Exception will be raised if the input is not string
+            log<level::ERR>(fmt::format("An invalid originatorType passed, "
+                                        "errormsg({})",
+                                        e.what())
+                                .c_str());
+            elog<InvalidArgument>(Argument::ARGUMENT_NAME("ORIGINATOR_TYPE"),
+                                  Argument::ARGUMENT_VALUE("INVALID INPUT"));
+        }
+    }
 }
 
 } // namespace dump


### PR DESCRIPTION

This new interface "OriginatedBy" will be implemented by all the dump entry dbus objects. It contains a property "OriginatorId" which stores the unique id of the user that has initiated the dump. The unique id in this case is a string that contains the ip address of the client that initiated the dump.

The dbus interface change for the same is at:
[1] https://gerrit.openbmc-project.xyz/c/openbmc/phosphor-dbus-interfaces/+/47057

Tested By:

[1] busctl call xyz.openbmc_project.Dump.Manager /xyz/openbmc_project/dump/bmc xyz.openbmc_project.Dump.Create CreateDump a{sv} 2 "xyz.openbmc_project.Dump.Create.CreateParameters.OriginatorId" s "<unique-id>" "xyz.openbmc_project.Dump.Create.CreateParameters.OriginatorType" s "xyz.openbmc_project.Common.OriginatedBy.OriginatorTypes.Client" o "/xyz/openbmc_project/dump/bmc/entry/2"

[2] busctl --verbose call xyz.openbmc_project.Dump.Manager /xyz/openbmc_project/dump/resource xyz.openbmc_project.Dump.Create CreateDump a{sv} 4 "com.ibm.Dump.Create.CreateParameters.VSPString" s "vsp" "com.ibm.Dump.Create.CreateParameters.Password" s "password" "com.ibm.Dump.Create.CreateParameters.OriginatorId" s "<unique-id>" "xyz.openbmc_project.Dump.Create.CreateParameters.OriginatorType" s "xyz.openbmc_project.Common.OriginatedBy.OriginatorTypes.Client" MESSAGE "o" {
        OBJECT_PATH "/xyz/openbmc_project/dump/resource/entry/1";
};

[3] busctl call xyz.openbmc_project.Dump.Manager /xyz/openbmc_project/dump/system xyz.openbmc_project.Dump.Create CreateDump a{sv} 2 "com.ibm.Dump.Create.CreateParameters.OriginatorId" s "<unique-id>" "xyz.openbmc_project.Dump.Create.CreateParameters.OriginatorType" s "xyz.openbmc_project.Common.OriginatedBy.OriginatorTypes.Client" o "/xyz/openbmc_project/dump/system/entry/1"


Corresponding upstream commit : (https://gerrit.openbmc.org/plugins/gitiles/openbmc/phosphor-debug-collector/+/74a1f39c56d970667b4ff5004ccc175dbe2f23b4)