### PR TITLE
Addition of PEL message method for dump delete/offload

### DIFF
--- a/bmcstored_dump_entry.cpp
+++ b/bmcstored_dump_entry.cpp
@@ -31,7 +31,9 @@ void Entry::delete_()
         elog<sdbusplus::xyz::openbmc_project::Common::Error::Unavailable>();
     }
 
-    // Delete Dump file from Permanent location
+    // Delete Dump file from Permanent location but before that copy the dump
+    // file name to be put in the PEL message
+    const auto strDumpFileName = path();
     log<level::ERR>(
         fmt::format("Deleting dump id({}) path({})", id, path()).c_str());
     try
@@ -50,6 +52,13 @@ void Entry::delete_()
 
     // Remove Dump entry D-bus object
     phosphor::dump::Entry::delete_();
+
+    // Log PEL for dump delete/offload
+    log<level::INFO>("Log PEL for dump delete or offload");
+    phosphor::dump::createPEL(
+        strDumpFileName, "BMC Dump", id,
+        "xyz.openbmc_project.Logging.Entry.Level.Informational",
+        "xyz.openbmc_project.Dump.Error.Invalidate");
 }
 
 void Entry::initiateOffload(std::string uri)

--- a/dump-extensions/openpower-dumps/resource_dump_entry.cpp
+++ b/dump-extensions/openpower-dumps/resource_dump_entry.cpp
@@ -116,6 +116,12 @@ void Entry::delete_()
                         path.string().c_str(), e.what())
                 .c_str());
     }
+    // Log PEL for dump /offload
+    log<level::INFO>("Log PEL for dump delete or offload");
+    phosphor::dump::createPEL(
+        path.string(), "Resource Dump", dumpId,
+        "xyz.openbmc_project.Logging.Entry.Level.Informational",
+        "xyz.openbmc_project.Dump.Error.Invalidate");
 }
 } // namespace resource
 } // namespace dump

--- a/dump-extensions/openpower-dumps/system_dump_entry.cpp
+++ b/dump-extensions/openpower-dumps/system_dump_entry.cpp
@@ -105,6 +105,13 @@ void Entry::delete_()
     log<level::INFO>(
         fmt::format("System dump entry with id({}) is deleted", dumpId)
             .c_str());
+
+    // Log PEL for dump delete/offload
+    log<level::INFO>("Log PEL for dump delete or offload");
+    phosphor::dump::createPEL(
+        path, "System Dump", dumpId,
+        "xyz.openbmc_project.Logging.Entry.Level.Informational",
+        "xyz.openbmc_project.Dump.Error.Invalidate");
 }
 
 void Entry::update(uint64_t timeStamp, uint64_t dumpSize,

--- a/dump_utils.cpp
+++ b/dump_utils.cpp
@@ -148,5 +148,47 @@ bool isHostQuiesced()
     }
     return false;
 }
+
+void createPEL(const std::string& dumpFilePath, const std::string& dumpFileType,
+               const int dumpId, const std::string& pelSev,
+               const std::string& errIntf)
+{
+    try
+    {
+        constexpr auto loggerObjectPath = "/xyz/openbmc_project/logging";
+        constexpr auto loggerCreateInterface =
+            "xyz.openbmc_project.Logging.Create";
+        constexpr auto loggerService = "xyz.openbmc_project.Logging";
+        constexpr auto dumpFileString = "File Name";
+        constexpr auto dumpFileTypeString = "Dump Type";
+        constexpr auto dumpIdString = "Dump ID";
+
+        sd_bus* pBus = nullptr;
+        sd_bus_default(&pBus);
+
+        // Implies this is a call from Manager. Hence we need to make an async
+        // call to avoid deadlock with Phosphor-logging.
+        auto retVal = sd_bus_call_method_async(
+            pBus, nullptr, loggerService, loggerObjectPath,
+            loggerCreateInterface, "Create", nullptr, nullptr, "ssa{ss}",
+            errIntf.c_str(), pelSev.c_str(), 3, dumpIdString,
+            std::to_string(dumpId).c_str(), dumpFileString,
+            dumpFilePath.c_str(), dumpFileTypeString, dumpFileType.c_str());
+
+        if (retVal < 0)
+        {
+            log<level::ERR>("Error calling sd_bus_call_method_async",
+                            entry("retVal=%d", retVal),
+                            entry("MSG=%s", strerror(-retVal)));
+        }
+    }
+    catch (const std::exception& e)
+    {
+        log<level::ERR>(
+            "Error in calling creating PEL. Standard exception caught",
+            entry("ERROR=%s", e.what()));
+    }
+}
+
 } // namespace dump
 } // namespace phosphor

--- a/dump_utils.hpp
+++ b/dump_utils.hpp
@@ -166,5 +166,19 @@ T readDBusProperty(sdbusplus::bus::bus& bus, const std::string& service,
     return retVal;
 }
 
+/**
+ * @brief Create a new PEL message for dump Delete/Offload
+ *
+ * @param[in] dumpFilePath - Deleted dump file path/name
+ * @param[in] dumpFileType - Deleted dump file type (BMC/Resource/System)
+ * @param[in] dumpId - The dump ID
+ * @param[in] pelSev - PEL severity (Informational by default)
+ * @param[in] errIntf - D-Bus interface name.
+ * @return Returns void
+ **/
+void createPEL(const std::string& dumpFilePath, const std::string& dumpFileType,
+               const int dumpId, const std::string& pelSev,
+               const std::string& errIntf);
+
 } // namespace dump
 } // namespace phosphor


### PR DESCRIPTION
Addition of PEL message method for dump delete/offload

Adding a createPEL method which will log PEL messages.
This method has PEL severity as Informational by default
unless mentioned otherwise

Change-Id: b4e1622407fa9aa372fe0f20f73509cb376f90c5
Signed-off-by: swarnendu.roy.chowdhury@ibm.com