### PR TITLE
1050: dreport: fix invalid -type related error

### DIFF
--- a/tools/dreport.d/dreport
+++ b/tools/dreport.d/dreport
@@ -215,11 +215,11 @@ function initialize()
     summary_log="$name_dir/$SUMMARY_LOG"
 
     #Type
-    if [[ $dump_type != $TYPE_USER ]] || \
-        [[ $dump_type != $TYPE_CORE ]] || \
-        [[ $dump_type != $TYPE_ELOG ]] || \
-        [[ $dump_type != $TYPE_RAMOOPS ]] || \
-        [[ $dump_type != $TYPE_CHECKSTOP ]]; then
+    if ! { [[ $dump_type = "$TYPE_USER" ]] || \
+            [[ $dump_type = "$TYPE_CORE" ]] || \
+            [[ $dump_type = "$TYPE_ELOG" ]] || \
+            [[ $dump_type = "$TYPE_RAMOOPS" ]] || \
+            [[ $dump_type = "$TYPE_CHECKSTOP" ]]; }; then
         log_error "Invalid -type, Only summary log is available"
         dump_type=$SUMMARY_DUMP
     fi


### PR DESCRIPTION
#### dreport: fix invalid -type related error
```
With recent beautysh updates dreport -type option is broken
with below error
 "Invalid -type, Only summary log is available"

Tested:
  verified dreport -v -t user.

Change-Id: Id3cc1d1165acc4e10b94268b91df448758cdd428
Signed-off-by: Jayanth Othayoth <ojayanth@in.ibm.com>
```