### PR TITLE
Add SystemSetup state to allow dump collection

### DIFF
--- a/dump_utils.cpp
+++ b/dump_utils.cpp
@@ -112,6 +112,7 @@ bool isHostRunning()
     // is running.
     BootProgress bootProgressStatus = phosphor::dump::getBootProgress();
     if ((bootProgressStatus == BootProgress::SystemInitComplete) ||
+        (bootProgressStatus == BootProgress::SystemSetup) ||
         (bootProgressStatus == BootProgress::OSStart) ||
         (bootProgressStatus == BootProgress::OSRunning) ||
         (bootProgressStatus == BootProgress::PCIInit))


### PR DESCRIPTION
This commit adds SystemSetup state as valid state to allow host dump collection

SystemSetup is a BootProgress that indicates the host is booted, needs to allow host
dump collection