### PR TITLE
Add utility method to create PEL for dump invalidation -- In more CPP way 

### DIFF
--- a/bmcstored_dump_entry.cpp
+++ b/bmcstored_dump_entry.cpp
@@ -31,7 +31,9 @@ void Entry::delete_()
         elog<sdbusplus::xyz::openbmc_project::Common::Error::Unavailable>();
     }
 
-    // Delete Dump file from Permanent location
+    // Delete Dump file from Permanent location but before that copy the dump
+    // file name to be put in the PEL message
+    const auto strDumpFileName = path();
     log<level::ERR>(
         fmt::format("Deleting dump id({}) path({})", id, path()).c_str());
     try
@@ -50,6 +52,13 @@ void Entry::delete_()
 
     // Remove Dump entry D-bus object
     phosphor::dump::Entry::delete_();
+
+    // Log PEL for dump delete/offload
+    log<level::INFO>("Log PEL for dump delete or offload");
+    phosphor::dump::createPEL(
+        strDumpFileName, "BMC Dump", id,
+        "xyz.openbmc_project.Logging.Entry.Level.Informational",
+        "xyz.openbmc_project.Dump.Error.Invalidate");
 }
 
 void Entry::initiateOffload(std::string uri)

--- a/dump-extensions/openpower-dumps/resource_dump_entry.cpp
+++ b/dump-extensions/openpower-dumps/resource_dump_entry.cpp
@@ -116,6 +116,12 @@ void Entry::delete_()
                         path.string().c_str(), e.what())
                 .c_str());
     }
+    // Log PEL for dump /offload
+    log<level::INFO>("Log PEL for dump delete or offload");
+    phosphor::dump::createPEL(
+        path.string(), "Resource Dump", dumpId,
+        "xyz.openbmc_project.Logging.Entry.Level.Informational",
+        "xyz.openbmc_project.Dump.Error.Invalidate");
 }
 } // namespace resource
 } // namespace dump

--- a/dump-extensions/openpower-dumps/system_dump_entry.cpp
+++ b/dump-extensions/openpower-dumps/system_dump_entry.cpp
@@ -105,6 +105,13 @@ void Entry::delete_()
     log<level::INFO>(
         fmt::format("System dump entry with id({}) is deleted", dumpId)
             .c_str());
+
+    // Log PEL for dump delete/offload
+    log<level::INFO>("Log PEL for dump delete or offload");
+    phosphor::dump::createPEL(
+        path, "System Dump", dumpId,
+        "xyz.openbmc_project.Logging.Entry.Level.Informational",
+        "xyz.openbmc_project.Dump.Error.Invalidate");
 }
 
 void Entry::update(uint64_t timeStamp, uint64_t dumpSize,

--- a/dump_utils.hpp
+++ b/dump_utils.hpp
@@ -166,5 +166,19 @@ T readDBusProperty(sdbusplus::bus::bus& bus, const std::string& service,
     return retVal;
 }
 
+/**
+ * @brief Create a new PEL message for dump Delete/Offload
+ *
+ * @param[in] dumpFilePath - Deleted dump file path/name
+ * @param[in] dumpFileType - Deleted dump file type (BMC/Resource/System)
+ * @param[in] dumpId - The dump ID
+ * @param[in] pelSev - PEL severity (Informational by default)
+ * @param[in] errIntf - D-Bus interface name.
+ * @return Returns void
+ **/
+void createPEL(const std::string& dumpFilePath, const std::string& dumpFileType,
+               const int dumpId, const std::string& pelSev,
+               const std::string& errIntf);
+
 } // namespace dump
 } // namespace phosphor

--- a/tools/dreport.d/ibm.d/plugins.d/badpel
+++ b/tools/dreport.d/ibm.d/plugins.d/badpel
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+#
+# config: 2 20
+# @brief: Save the 'badPEL' file
+#
+
+. $DREPORT_INCLUDE/functions
+
+desc="Bad PEL file"
+file_name="/var/lib/phosphor-logging/extensions/pels/badPEL"
+
+if [ -e "$file_name" ]; then
+  add_copy_file "$file_name" "$desc"
+fi


### PR DESCRIPTION
Adding an utility method createPEL to help to log PEL messages
for dump delete/invalidation. This method has PEL severity as Informational
by default unless mentioned otherwise.
    
Change-Id: b4e1622407fa9aa372fe0f20f73509cb376f90c5
Signed-off-by: Swarnendu Roy Chowdhury <swarnendu.roy.chowdhury@ibm.com>