### PR TITLE
Addition of PEL message method for dump delete/offload

### DIFF
--- a/bmcstored_dump_entry.cpp
+++ b/bmcstored_dump_entry.cpp
@@ -1,6 +1,7 @@
 #include "bmc_dump_entry.hpp"
 #include "dump_manager.hpp"
 #include "dump_offload.hpp"
+#include "dump_utils.hpp"
 
 #include <fmt/core.h>
 
@@ -16,6 +17,15 @@ using namespace phosphor::logging;
 
 void Entry::delete_()
 {
+    // Log PEL for dump delete/offload
+    {
+        auto dBus = sdbusplus::bus::new_default();
+        phosphor::dump::createPEL(
+            dBus, path(), "BMC Dump", id,
+            "xyz.openbmc_project.Logging.Entry.Level.Informational",
+            "xyz.openbmc_project.Dump.Error.Invalidate");
+    }
+
     // Delete Dump file from Permanent location
     try
     {

--- a/dump-extensions/openpower-dumps/resource_dump_entry.cpp
+++ b/dump-extensions/openpower-dumps/resource_dump_entry.cpp
@@ -46,6 +46,7 @@ void Entry::delete_()
 {
     auto srcDumpID = sourceDumpId();
     auto dumpId = id;
+    auto dumpPathOffLoadUri = offloadUri();
 
     if ((!offloadUri().empty()) && (phosphor::dump::isHostRunning()))
     {
@@ -82,6 +83,13 @@ void Entry::delete_()
 
     // Remove Dump entry D-bus object
     phosphor::dump::Entry::delete_();
+
+    // Log PEL for dump /offload
+    auto dBus = sdbusplus::bus::new_default();
+    phosphor::dump::createPEL(
+        dBus, dumpPathOffLoadUri, "Resource Dump", dumpId,
+        "xyz.openbmc_project.Logging.Entry.Level.Informational",
+        "xyz.openbmc_project.Dump.Error.Invalidate");
 }
 } // namespace resource
 } // namespace dump

--- a/dump-extensions/openpower-dumps/system_dump_entry.cpp
+++ b/dump-extensions/openpower-dumps/system_dump_entry.cpp
@@ -37,6 +37,7 @@ void Entry::delete_()
 {
     auto srcDumpID = sourceDumpId();
     auto dumpId = id;
+    auto dumpPathOffLoadUri = offloadUri();
 
     // Skip the system dump delete if the dump is in progress
     // and in memory preserving reboot path
@@ -85,6 +86,13 @@ void Entry::delete_()
 
     // Remove Dump entry D-bus object
     phosphor::dump::Entry::delete_();
+
+    // Log PEL for dump delete/offload
+    auto dBus = sdbusplus::bus::new_default();
+    phosphor::dump::createPEL(
+        dBus, dumpPathOffLoadUri, "System Dump", dumpId,
+        "xyz.openbmc_project.Logging.Entry.Level.Informational",
+        "xyz.openbmc_project.Dump.Error.Invalidate");
 }
 } // namespace system
 } // namespace dump

--- a/dump_utils.cpp
+++ b/dump_utils.cpp
@@ -3,6 +3,7 @@
 #include <fmt/core.h>
 
 #include <phosphor-logging/log.hpp>
+#include <sdbusplus/async.hpp>
 
 namespace phosphor
 {
@@ -139,5 +140,58 @@ bool isHostQuiesced()
 {
     return (phosphor::dump::getHostState() == HostState::Quiesced);
 }
+
+void createPEL(sdbusplus::bus::bus& dBus, const std::string& dumpFilePath,
+               const std::string& dumpFileType, const int dumpId,
+               const std::string& pelSev, const std::string& errIntf)
+{
+    try
+    {
+        constexpr auto loggerObjectPath = "/xyz/openbmc_project/logging";
+        constexpr auto loggerCreateInterface =
+            "xyz.openbmc_project.Logging.Create";
+        constexpr auto loggerService = "xyz.openbmc_project.Logging";
+
+        constexpr auto dumpFileString = "File Name";
+        constexpr auto dumpFileTypeString = "Dump Type";
+        constexpr auto dumpIdString = "Dump ID";
+
+        const std::unordered_map<std::string_view, std::string_view>
+            userDataMap = {{dumpIdString, std::to_string(dumpId)},
+                           {dumpFileString, dumpFilePath},
+                           {dumpFileTypeString, dumpFileType}};
+
+        // Set up a connection to D-Bus object
+        auto busMethod = dBus.new_method_call(loggerService, loggerObjectPath,
+                                              loggerCreateInterface, "Create");
+        busMethod.append(errIntf, pelSev, userDataMap);
+
+        // Implies this is a call from Manager. Hence we need to make an async
+        // call to avoid deadlock with Phosphor-logging.
+        auto retVal =
+            busMethod.call_async([&](sdbusplus::message::message&& reply) {
+                if (reply.is_method_error())
+                {
+                    log<level::INFO>(
+                        "Error in calling async method to create PEL");
+                }
+                else
+                {
+                    log<level::ERR>(
+                        "Success calling async method to create PEL");
+                }
+            });
+        if (!retVal)
+        {
+            log<level::ERR>("Return object contains null pointer");
+        }
+    }
+    catch (const sdbusplus::exception::SdBusError& e)
+    {
+        log<level::ERR>("Error in calling creating PEL. Exception caught",
+                        entry("ERROR=%s", e.what()));
+    }
+}
+
 } // namespace dump
 } // namespace phosphor

--- a/dump_utils.hpp
+++ b/dump_utils.hpp
@@ -243,5 +243,20 @@ T readDBusProperty(sdbusplus::bus::bus& bus, const std::string& service,
     return retVal;
 }
 
+/**
+ * @brief Create a new PEL message for dump Delete/Offload
+ *
+ * @param[in] dBus - Handle to D-Bus object
+ * @param[in] dumpFilePath - Deleted dump file path/name
+ * @param[in] dumpFileType - Deleted dump file type (BMC/Resource/System)
+ * @param[in] dumpId - The dump ID
+ * @param[in] pelSev - PEL severity (Informational by default)
+ * @param[in] errIntf - D-Bus interface name.
+ * @return Returns void
+ **/
+void createPEL(sdbusplus::bus::bus& dBus, const std::string& dumpFilePath,
+               const std::string& dumpFileType, const int dumpId,
+               const std::string& pelSev, const std::string& errIntf);
+
 } // namespace dump
 } // namespace phosphor


### PR DESCRIPTION
Addition of PEL message method for dump delete/offload

Adding a createPEL method which will log PEL messages.
This method has PEL severity as Informational by default
unless mentioned otherwise

Gerrit review link https://gerrit.openbmc.org/c/openbmc/phosphor-debug-collector/+/53547

Create an info PEL when doing a dump invalidation/delete
    
When a dump is been ofloaded and subsequently deleted by a HMC
managed system or by any other means now it is logging
a PEL message having the information of about that deleted
dump file like Dump Type, Dump File Name and Dump ID.
![image (1)](https://user-images.githubusercontent.com/112170550/221136069-68102fcb-eead-4c2d-a00f-4cb50070f913.png)
![image](https://user-images.githubusercontent.com/112170550/221136084-ebd43227-88dc-4795-b865-94688574e5cb.png)


Signed-off-by: swarnendu.roy.chowdhury@ibm.com