### PR TITLE
Add utility method to create PEL for dump invalidation

### DIFF
--- a/dump_utils.cpp
+++ b/dump_utils.cpp
@@ -172,13 +172,8 @@ void createPEL(sdbusplus::bus::bus& dBus, const std::string& dumpFilePath,
             busMethod.call_async([&](sdbusplus::message::message&& reply) {
                 if (reply.is_method_error())
                 {
-                    log<level::INFO>(
-                        "Error in calling async method to create PEL");
-                }
-                else
-                {
                     log<level::ERR>(
-                        "Success calling async method to create PEL");
+                        "Error in calling async method to create PEL");
                 }
             });
         if (!retVal)


### PR DESCRIPTION
Adding an utility method createPEL to help to log PEL messages for dump delete/invalidation. This method has PEL severity as Informational by default unless mentioned otherwise.

***No functional changes than earlier commit https://github.com/ibm-openbmc/phosphor-debug-collector/pull/92, only the log level enum has been changed so no further testing is required***

Upstream has been updated also in accordence https://gerrit.openbmc.org/c/openbmc/phosphor-debug-collector/+/53547

Change-Id: 2f9b01a0e0cee906e9549acf160b9456ae48e87d
Signed-off-by: Swarnendu Roy Chowdhury <swarnendu.roy.chowdhury@ibm.com>