### PR TITLE
1050 : Port dump related defect fixes from master

### DIFF
--- a/dump-extensions/openpower-dumps/dump_manager_hostdump.hpp
+++ b/dump-extensions/openpower-dumps/dump_manager_hostdump.hpp
@@ -18,10 +18,13 @@
 #include <com/ibm/Dump/Create/server.hpp>
 #include <phosphor-logging/elog-errors.hpp>
 #include <phosphor-logging/elog.hpp>
+#include <sdeventplus/exception.hpp>
+#include <sdeventplus/source/child.hpp>
 #include <xyz/openbmc_project/Dump/Create/server.hpp>
 
 #include <ctime>
 #include <filesystem>
+#include <map>
 #include <regex>
 
 namespace openpower
@@ -33,6 +36,7 @@ namespace hostdump
 
 using namespace sdbusplus::xyz::openbmc_project::Common::Error;
 using namespace phosphor::logging;
+using ::sdeventplus::source::Child;
 
 constexpr auto INVALID_DUMP_SIZE = 0;
 
@@ -198,6 +202,8 @@ class Manager :
   private:
     std::string dumpNamePrefix;
     std::string dumpTempFileDir;
+    /** @brief map of SDEventPlus child pointer added to event loop */
+    std::map<pid_t, std::unique_ptr<Child>> childPtrMap;
 
     void captureDump(uint32_t dumpId)
     {
@@ -252,22 +258,43 @@ class Manager :
             {
                 dumpEntry = dumpIt->second.get();
             }
-            // TODO switch to use sdeventplus Child as the inode entry create
-            // below is not released
-            auto rc =
-                sd_event_add_child(eventLoop.get(), nullptr, pid,
-                                   WEXITED | WSTOPPED, callback, dumpEntry);
-            if (0 > rc)
+            Child::Callback callback = [this, dumpEntry,
+                                        pid](Child&, const siginfo_t* si) {
+                // Set progress as failed if packaging return error
+                if (si->si_status != 0)
+                {
+                    log<level::ERR>("Dump packaging failed");
+                    if (dumpEntry != nullptr)
+                    {
+                        reinterpret_cast<phosphor::dump::Entry*>(dumpEntry)
+                            ->status(phosphor::dump::OperationStatus::Failed);
+                    }
+                }
+                else
+                {
+                    log<level::INFO>("Dump packaging completed");
+                }
+                this->childPtrMap.erase(pid);
+            };
+            try
             {
+                childPtrMap.emplace(
+                    pid, std::make_unique<Child>(eventLoop.get(), pid,
+                                                 WEXITED | WSTOPPED,
+                                                 std::move(callback)));
+            }
+            catch (const sdeventplus::SdEventError& ex)
+            {
+                // Failed to add to event loop
                 // Failed to add to event loop
                 log<level::ERR>(
                     fmt::format("Dump capture: Error occurred during "
-                                "the sd_event_add_child call, rc({})",
-                                rc)
+                                "the  sdeventplus::source::Child ex({})",
+                                ex.what())
                         .c_str());
                 throw std::runtime_error(
                     "Dump capture: Error occurred during the "
-                    "sd_event_add_child call");
+                    "sdeventplus::source::Child creation");
             }
         }
         else

--- a/dump_manager_bmc.cpp
+++ b/dump_manager_bmc.cpp
@@ -174,6 +174,37 @@ uint32_t Manager::captureDump(Type type,
     return ++lastEntryId;
 }
 
+void Manager::restore()
+{
+    phosphor::dump::bmc_stored::Manager::restore();
+    checkAndCreateCoreDump();
+}
+
+void Manager::checkAndCreateCoreDump()
+{
+    if (std::filesystem::exists(CORE_FILE_DIR) &&
+        std::filesystem::is_directory(CORE_FILE_DIR))
+    {
+        std::vector<std::string> files;
+        for (auto const& file :
+             std::filesystem::directory_iterator(CORE_FILE_DIR))
+        {
+            if (std::filesystem::is_regular_file(file) &&
+                (file.path().filename().string().starts_with("core.")))
+            {
+                // Consider only file name start with "core."
+                files.push_back(file.path().string());
+            }
+        }
+        if (!files.empty())
+        {
+            log<level::INFO>(
+                fmt::format("Core file found, files size {}", files.size())
+                    .c_str());
+            captureDump(Type::ApplicationCored, files);
+        }
+    }
+}
 } // namespace bmc
 } // namespace dump
 } // namespace phosphor

--- a/dump_manager_bmc.hpp
+++ b/dump_manager_bmc.hpp
@@ -5,9 +5,11 @@
 #include "watch.hpp"
 #include "xyz/openbmc_project/Dump/Internal/Create/server.hpp"
 
+#include <sdeventplus/source/child.hpp>
 #include <xyz/openbmc_project/Dump/Create/server.hpp>
 
 #include <filesystem>
+#include <map>
 
 namespace phosphor
 {
@@ -28,6 +30,7 @@ using CreateIface = sdbusplus::server::object_t<
 using Type =
     sdbusplus::xyz::openbmc_project::Dump::Internal::server::Create::Type;
 
+using ::sdeventplus::source::Child;
 // Type to dreport type  string map
 static const std::map<Type, std::string> TypeMap = {
     {Type::ApplicationCored, "core"},
@@ -103,6 +106,13 @@ class Manager :
      *  @return id - The Dump entry id number.
      */
     uint32_t captureDump(Type type, const std::vector<std::string>& fullPaths);
+
+    /** @brief Flag to reject user intiated dump if a dump is in progress*/
+    // TODO: https://github.com/openbmc/phosphor-debug-collector/issues/19
+    static bool fUserDumpInProgress;
+
+    /** @brief map of SDEventPlus child pointer added to event loop */
+    std::map<pid_t, std::unique_ptr<Child>> childPtrMap;
 };
 
 } // namespace bmc

--- a/dump_manager_bmc.hpp
+++ b/dump_manager_bmc.hpp
@@ -98,6 +98,11 @@ class Manager :
                      std::string originatorId,
                      originatorTypes originatorType) override;
 
+    /** @brief Construct dump d-bus objects from their persisted
+     *        representations.
+     */
+    void restore() override;
+
   private:
     /**  @brief Capture BMC Dump based on the Dump type.
      *  @param[in] type - Type of the Dump.
@@ -106,6 +111,10 @@ class Manager :
      *  @return id - The Dump entry id number.
      */
     uint32_t captureDump(Type type, const std::vector<std::string>& fullPaths);
+
+    /** @brief Check if any core files present and create BMC core dump
+     */
+    void checkAndCreateCoreDump();
 
     /** @brief Flag to reject user intiated dump if a dump is in progress*/
     // TODO: https://github.com/openbmc/phosphor-debug-collector/issues/19

--- a/dump_manager_bmcstored.hpp
+++ b/dump_manager_bmcstored.hpp
@@ -101,33 +101,6 @@ class Manager : public phosphor::dump::Manager
     EventPtr eventLoop;
 
   protected:
-    /** @brief sd_event_add_child callback
-     *
-     *  @param[in] s - event source
-     *  @param[in] si - signal info
-     *  @param[in] userdata - pointer to Watch object
-     *
-     *  @returns 0 on success, -1 on fail
-     */
-    static int callback(sd_event_source*, const siginfo_t* si, void* entry)
-    {
-        // Set progress as failed if packaging return error
-        if (si->si_status != 0)
-        {
-            log<level::ERR>("Dump packaging failed");
-            if (entry != NULL)
-            {
-                reinterpret_cast<phosphor::dump::Entry*>(entry)->status(
-                    phosphor::dump::OperationStatus::Failed);
-            }
-        }
-        else
-        {
-            log<level::INFO>("Dump packaging completed");
-        }
-        return 0;
-    }
-
     /** @brief Calculate per dump allowed size based on the available
      *        size in the dump location.
      *  @returns dump size in kilobytes.

--- a/meson.build
+++ b/meson.build
@@ -27,6 +27,7 @@ libsystemd = dependency('libsystemd', version : '>=221')
 sdbusplus_dep = dependency('sdbusplus')
 sdbusplusplus_prog = find_program('sdbus++')
 sdbuspp_gen_meson_prog = find_program('sdbus++-gen-meson')
+sdeventplus_dep = dependency('sdeventplus')
 
 phosphor_dbus_interfaces_dep = dependency('phosphor-dbus-interfaces')
 phosphor_logging_dep = dependency('phosphor-logging')
@@ -190,6 +191,7 @@ phosphor_dump_manager_sources = [
 phosphor_dump_manager_dependency = [
         phosphor_dbus_interfaces_dep,
         sdbusplus_dep,
+        sdeventplus_dep,
         phosphor_logging_dep,
         fmt_dep,
         cereal_dep,

--- a/subprojects/sdeventplus.wrap
+++ b/subprojects/sdeventplus.wrap
@@ -1,0 +1,6 @@
+[wrap-git]
+url = https://github.com/openbmc/sdeventplus.git
+revision = HEAD
+
+[provide]
+sdeventplus = sdeventplus_dep


### PR DESCRIPTION
1) Allow only 1 user dump at a time
2) Release inode after callback method for bmc dumps
3) Release inode after callback for host dumps
4) Check and capture core dump during restart of dump manager