### PR TITLE
1050 audit log

### DIFF
--- a/tools/dreport.d/plugins.d/auditlog
+++ b/tools/dreport.d/plugins.d/auditlog
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+#
+# config: 2 40
+# @brief: Save the audit log
+#
+
+. $DREPORT_INCLUDE/functions
+
+desc="Audit Log"
+file_name="audit-log.log"
+
+if [ -e "/var/log/audit/audit.log" ]; then
+  add_copy_file "$file_name" "$desc"
+fi

--- a/tools/dreport.d/plugins.d/auditlog
+++ b/tools/dreport.d/plugins.d/auditlog
@@ -6,9 +6,14 @@
 
 . $DREPORT_INCLUDE/functions
 
+# Multiple audit.log files can exist in the $log_path
+# directory. Copy all that exist to the dump.
+# The default configuration will limit to 5 files of
+# 2MB at most each. But if the configuration is altered we
+# want to copy all of the files which exist.
 desc="Audit Log"
-file_name="audit-log.log"
+log_path="/var/log/audit/"
 
-if [ -e "/var/log/audit/audit.log" ]; then
-  add_copy_file "$file_name" "$desc"
+if [ -e "$log_path" ]; then
+  add_copy_file "$log_path" "$desc"
 fi


### PR DESCRIPTION
Pull in changes needed to add audit log to BMC dump for 1050.

Audit log is not enabled yet. The directory does not exist until it is enabled, so this plugin will be a noop until then.

Upstream gerrit link: https://gerrit.openbmc.org/c/openbmc/phosphor-debug-collector/+/61954