### PR TITLE
Fixes for NAG

### DIFF
--- a/dump_manager_bmcstored.cpp
+++ b/dump_manager_bmcstored.cpp
@@ -34,7 +34,14 @@ uint64_t timeToEpoch(std::string timeStr)
     ss >> std::get_time(&t, "%Y%m%d%H%M%S");
     if (ss.fail())
     {
-        throw std::runtime_error{"Invalid human readable time value"};
+        // Dump will not be listed if the time is not format
+        // but to get the dump listed, setting the current time.
+        log<level::ERR>(
+            fmt::format("Invalid human readable time value({})", timeStr)
+                .c_str());
+        return std::chrono::duration_cast<std::chrono::microseconds>(
+                   std::chrono::system_clock::now().time_since_epoch())
+            .count();
     }
     return mktime(&t);
 }

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -277,7 +277,7 @@ option('BMC_DUMP_FILENAME_REGEX', type: 'string',
       )
 
 option('SYS_DUMP_FILENAME_REGEX', type: 'string',
-        value: 'SYSDUMP.([a-zA-Z0-9]+).([0-9]+).([0-9]+)',
+        value: '(SYSDUMP).([a-zA-Z0-9]+).([0-9]+).([0-9]+)',
         description : 'System dump file format'
       )
 

--- a/tools/dreport.d/ibm.d/plugins.d/faultlog
+++ b/tools/dreport.d/ibm.d/plugins.d/faultlog
@@ -5,6 +5,7 @@
 #
 
 . $DREPORT_INCLUDE/functions
+export PDBG_DTB=/var/lib/phosphor-software-manager/hostfw/running/DEVTREE
 
 desc="faultlog"
 file_name="faultlog.json"


### PR DESCRIPTION
63094: OpenPOWER: Fix the system dump filename format | https://gerrit.openbmc.org/c/openbmc/phosphor-debug-collector/+/63094

63095: OpenPOWER: Set the device tree path in script | https://gerrit.openbmc.org/c/openbmc/phosphor-debug-collector/+/63095