### PR TITLE
Remove the duplicate DUMP_FILENAME_REGEX from meson_options.txt

### DIFF
--- a/meson_options.txt
+++ b/meson_options.txt
@@ -335,16 +335,6 @@ option('SBE_DUMP_START_ID', type : 'integer',
         description : 'Starting id of SBE Dump'
       )
 
-option('BMC_DUMP_FILENAME_REGEX', type: 'string',
-        value: 'obmcdump_([0-9]+)_([0-9]+).([a-zA-Z0-9]+)',
-        description : 'BMC dump file format'
-      )
-
-option('SYS_DUMP_FILENAME_REGEX', type: 'string',
-        value: 'SYSDUMP.([a-zA-Z0-9]+).([0-9]+).([0-9]+)',
-        description : 'System dump file format'
-      )
-
 option('FILENAME_DUMP_ID_POS', type : 'integer',
         value : 1,
         description : 'Position of dump id in dump filename'


### PR DESCRIPTION
There was a duplicate SYS_DUMP_FILENAME_REGEX and
BMC_DUMP_FILENAME_REGEX which might came from a
wrong merge, removing the duplicate one