### PR TITLE
dreport: Adding NAG DUMP support in header

### DIFF
--- a/tools/dreport.d/dreport
+++ b/tools/dreport.d/dreport
@@ -84,6 +84,7 @@ declare -x elog_id=""
 declare -x dDay=$(date -d @$EPOCHTIME +'%Y%m%d%H%M%S')
 declare -x serialNo=""
 declare -x FILE=""
+declare -x header_dump_name=""
 
 #Source dreport common functions
 . $DREPORT_INCLUDE/functions
@@ -196,8 +197,10 @@ function initialize()
             fetch_serial_number
             dump_id=$(printf %07d $dump_id)
             if [ $dump_type = "$TYPE_FAULTDATA" ]; then
+                header_dump_name="FLTDUMP"
                 name="NAGDUMP.${serialNo}.${dump_id}.${dDay}"
             else
+                header_dump_name="BMCDUMP"
                 name="BMCDUMP.${serialNo}.${dump_id}.${dDay}"
             fi
         else

--- a/tools/dreport.d/ibm.d/gendumpheader
+++ b/tools/dreport.d/ibm.d/gendumpheader
@@ -226,7 +226,7 @@ function get_bmc_model_serial_number() {
 #Reserved          10           NULL
 #Entry Type        2            0x0001
 #File Name Prefix  2            0x000F
-#Dump File Type    7            BMCDUMP/SYSDUMP
+#Dump File Type    7            BMCDUMP/SYSDUMP/NAGDUMP
 #Separator         1            .
 #System Serial No  7            System serial number fetched from system
 #Dump Identifier   8            Dump Identifier value fetched from dump
@@ -244,7 +244,7 @@ function dump_file_entry() {
     if [ "$dump_type" = "$OP_DUMP" ]; then
         printf "SYSDUMP.%s." "$serialNo" >> "$FILE"
     else
-        printf "BMCDUMP.%s." "$serialNo" >> "$FILE"
+        printf "%s.%s." "$header_dump_name" "$serialNo" >> "$FILE"
     fi
     get_dump_id
     printf "." >> $FILE
@@ -263,7 +263,7 @@ function dump_file_entry() {
 #Entry Types       2            0x0002
 #Reserved          2            NULL
 #Dump Size         8            Dump size in hex + dump header
-#Optional Section  16           BMCDUMP/DUMP SUMMARY
+#Optional Section  16           BMCDUMP/NAGDUMP/DUMP SUMMARY
 function dump_section_entry() {
     printf "SECTION " >> $FILE
     add_null 1
@@ -285,7 +285,7 @@ function dump_section_entry() {
         add_null 4
     else
         dump_size    #Dump size
-        printf "BMCDUMP" >> "$FILE"
+        printf "%s" "$header_dump_name" >> "$FILE"
         add_null 9
     fi
 }
@@ -293,7 +293,7 @@ function dump_section_entry() {
 #Function to add dump header, consists of below entries
 ####################FORMAT################
 #Name              Size(bytes)  Value
-#Dump type         8            BMC DUMP
+#Dump type         8            BMC/NAG DUMP
 #Dump Request time 8            Dump request time stamp (in BCD)
 #Dump Identifier   4            Dump identifer fetched from dump
 #Dump version      2            0x0210
@@ -320,7 +320,11 @@ function dump_section_entry() {
 #Dump Req ID
 #Dump Req user ID
 function dump_header() {
-    printf "BMC DUMP" >> $FILE
+    if [ $dump_type = "$TYPE_FAULTDATA" ]; then
+        printf "FLT DUMP" >> $FILE
+    else
+        printf "BMC DUMP" >> $FILE
+    fi
     dump_time
     add_null 4 #Dump Identifier
     printf '\x02' >> $FILE #Dump version 0x0210

--- a/tools/dreport.d/ibm.d/package
+++ b/tools/dreport.d/ibm.d/package
@@ -6,7 +6,13 @@ function custom_package()
 {
     FILE="/tmp/dumpheader_${dump_id}_${EPOCHTIME}"
     echo "performing dump compression $name_dir"
-    tar cf - -C "$(dirname "$name_dir")" "$(basename "$name_dir")"  | zstd > "$name_dir.bin"
+    if [ "$dump_type" = "$TYPE_FAULTDATA" ]; then
+        rm -rf $name_dir/dreport.log
+        rm -rf $name_dir/summary.log
+        tar -cf "$name_dir.bin" -C "$(dirname "$name_dir")" "$(basename "$name_dir")"
+    else
+        tar cf - -C "$(dirname "$name_dir")" "$(basename "$name_dir")"  | zstd > "$name_dir.bin"
+    fi
     # shellcheck disable=SC2181 # need output from `tar` in above if cond.
     if [ $? -ne 0 ]; then
         echo "$($TIME_STAMP)" "Could not create the compressed tar file"


### PR DESCRIPTION
Change:
For dump type faultdata the name in the header shpuld be NAGDUMP, so that HMC can recognize the type of dump from header.

Tested:
Post changes can see header is getting updated with name NAGDUMP.