### PR TITLE
opdreport: Added check for errorlog

### DIFF
--- a/tools/dreport.d/ibm.d/gendumpheader
+++ b/tools/dreport.d/ibm.d/gendumpheader
@@ -126,13 +126,17 @@ function get_eid() {
     if [ "$dump_type" = "$OP_DUMP" ]; then
         # shellcheck disable=SC2154 # elog_id comes from elsewhere
         x=${#elog_id}
-        msize=$(( x / 2 ))
-        msize=$(( SIZE_4 - msize ))
-        for ((i=0;i<x;i+=2));
-        do
-            printf "\\x${elog_id:$i:2}" >> "$FILE"
-        done
-        add_null "$msize"
+        if [ "$x" = 8 ]; then
+            msize=$(( x / 2 ))
+            msize=$(( SIZE_4 - msize ))
+            for ((i=0;i<x;i+=2));
+            do
+                printf "\\x${elog_id:$i:2}" >> "$FILE"
+            done
+            add_null "$msize"
+        else
+            add_null 4
+        fi
     else
         add_null 4
     fi

--- a/tools/dreport.d/openpower.d/opdreport
+++ b/tools/dreport.d/openpower.d/opdreport
@@ -16,12 +16,19 @@ Options:
         -d, —-dir <directory> Archive directory to copy the compressed report.
                               Default output directory is current working
                               directory. Optional parameter.
-        -i, —-dumpid <id>         Dump identifier to associate with the archive.
+        -i, —-dumpid <id>     Dump identifier to associate with the archive.
                               Identifiers include numeric characters.
                               Default dump identifier is 0
         -s, --size <size>     Maximum allowed size(in KB) of the archive.
                               Report will be truncated in case size exceeds
                               this limit. Default size is unlimited.
+        -f, --failingunit     The id of the failed unit
+        -e, --eid             Error log associated with the failure
+        -t, --type            Type of the dump to be collected
+                              1  -  Hardware dump
+                              3  -  Performance dump
+                              5  -  Hostboot dump
+                              10 -  SBE Dump
         -h, —-help            Display this help and exit.
 EOF
 )
@@ -140,11 +147,11 @@ function package()
 
     cd "$content_path" || exit
 
-    dump_content_type=${dump_id:0:2}
+    dump_content_type=${id:0:2}
 
     ("$FILE_SCRIPT")
 
-    elog_id=eid
+    elog_id=$eid
 
     tar -cvzf "$name" plat_dump/*Sbe* info.yaml
     # shellcheck disable=SC2181 # need output from `tar` in above if cond.


### PR DESCRIPTION
Changes:
Added check for errorlog, so that during packaging we don't write extra bytes in header.
Corrected the content_type to fetch correct dump id.

Tested:
Post changes makedump tool is able to extract the platform dumps.

Change-Id: Ib6116d0a2660c25da8e06adc020db4632bf4d1bc