### PR TITLE
Dump offload fixes

### DIFF
--- a/bmcstored_dump_entry.cpp
+++ b/bmcstored_dump_entry.cpp
@@ -56,12 +56,13 @@ void Entry::delete_()
 
 void Entry::initiateOffload(std::string uri)
 {
-    if ((isOffloadInProgress()) && (uri == offloadUri()))
+    if (isOffloadInProgress())
     {
-        log<level::ERR>(fmt::format("Another offload is in progress with same "
-                                    "URI({}), cannot continue",
-                                    offloadUri())
-                            .c_str());
+        log<level::ERR>(
+            fmt::format(
+                "Another offload is in progress URI({}) id({}) cannot continue",
+                offloadUri(), id)
+                .c_str());
         elog<NotAllowed>(
             Reason("Another offload is in progress, please try later"));
     }

--- a/bmcstored_dump_entry.cpp
+++ b/bmcstored_dump_entry.cpp
@@ -1,11 +1,16 @@
 #include "bmc_dump_entry.hpp"
-#include "dump_manager.hpp"
+#include "dump_manager_bmcstored.hpp"
 #include "dump_offload.hpp"
 #include "dump_utils.hpp"
+#include "xyz/openbmc_project/Common/error.hpp"
 
 #include <fmt/core.h>
 
+#include <phosphor-logging/elog-errors.hpp>
+#include <phosphor-logging/elog.hpp>
 #include <phosphor-logging/log.hpp>
+#include <sdeventplus/exception.hpp>
+#include <sdeventplus/source/base.hpp>
 
 namespace phosphor
 {
@@ -14,6 +19,8 @@ namespace dump
 namespace bmc_stored
 {
 using namespace phosphor::logging;
+using NotAllowed = sdbusplus::xyz::openbmc_project::Common::Error::NotAllowed;
+using Reason = xyz::openbmc_project::Common::NotAllowed::REASON;
 
 void Entry::delete_()
 {
@@ -38,8 +45,82 @@ void Entry::delete_()
 
 void Entry::initiateOffload(std::string uri)
 {
-    phosphor::dump::offload::requestOffload(path(), id, uri);
-    offloaded(true);
+    if ((isOffloadInProgress()) && (uri == offloadUri()))
+    {
+        log<level::ERR>(fmt::format("Another offload is in progress with same "
+                                    "URI({}), cannot continue",
+                                    offloadUri())
+                            .c_str());
+        elog<NotAllowed>(
+            Reason("Another offload is in progress, please try later"));
+    }
+
+    setOffloadInProgress();
+
+    log<level::INFO>(
+        fmt::format("offload started id({}) uri({})", id, uri).c_str());
+
+    phosphor::dump::Entry::initiateOffload(uri);
+    pid_t pid = fork();
+    if (pid == 0)
+    {
+        execl("/usr/bin/phosphor-offload-handler", "phosphor-offload-handler",
+              "--id", std::to_string(id).c_str(), "--path", path().c_str(),
+              "--uri", uri.c_str(), nullptr);
+        log<level::ERR>(fmt::format("Dump offload failure: Error occured while "
+                                    "starting offload id({})",
+                                    id)
+                            .c_str());
+        std::exit(EXIT_FAILURE);
+    }
+
+    if (pid > 0)
+    {
+        Child::Callback callback = [this](Child&, const siginfo_t* si) {
+            this->resetOffloadInProgress();
+            if (si->si_status == 0)
+            {
+                this->offloaded(true);
+                log<level::ERR>(fmt::format("Dump offload completed id({})",
+                                            this->getDumpId())
+                                    .c_str());
+            }
+            else
+            {
+                log<level::ERR>(
+                    fmt::format("Dump offload failed id({})", this->getDumpId())
+                        .c_str());
+            }
+            this->childPtr.reset();
+        };
+        try
+        {
+            childPtr = std::make_unique<Child>(
+                dynamic_cast<phosphor::dump::bmc_stored::Manager&>(parent)
+                    .eventLoop.get(),
+                pid, WEXITED | WSTOPPED, std::move(callback));
+        }
+        catch (const sdeventplus::SdEventError& ex)
+        {
+            // Failed to add to event loop
+            log<level::ERR>(
+                fmt::format("Dump offload: Error occurred during "
+                            "the sdeventplus::source::Child creation, ex({})",
+                            ex.what())
+                    .c_str());
+            throw std::runtime_error("Dump offload: Error occurred during the "
+                                     "sdeventplus::source::Child call");
+        }
+    }
+    else
+    {
+        auto error = errno;
+        log<level::ERR>(
+            fmt::format("Dump offload: Error occurred during fork, errno({})",
+                        error)
+                .c_str());
+        throw std::runtime_error("Dump offload: Error occurred during fork");
+    }
 }
 
 } // namespace bmc_stored

--- a/bmcstored_dump_entry.cpp
+++ b/bmcstored_dump_entry.cpp
@@ -24,7 +24,18 @@ using Reason = xyz::openbmc_project::Common::NotAllowed::REASON;
 
 void Entry::delete_()
 {
+    if (isOffloadInProgress())
+    {
+        log<level::ERR>(
+            fmt::format("Dump offload is in progress, cannot delete id({})", id)
+                .c_str());
+        elog<NotAllowed>(
+            Reason("Dump offload is in progress, please try later"));
+    }
+
     // Delete Dump file from Permanent location
+    log<level::ERR>(
+        fmt::format("Deleting dump id({}) path({})", id, path()).c_str());
     try
     {
         std::filesystem::remove_all(


### PR DESCRIPTION
There were some merge conflicts with bmcstores_dump_entry.cpp - it was accidentally overwritten. A modification from commit 1030 wasn't pushed to the master branch. To resolve this, I've updated the master branch and pulled the changes into commit 1050.

Testing procedures:

A BMC dump was successfully created and offloaded.
Validated that deletion is disabled during offloading.
Confirmed that multiple simultaneous offloads are prevented.
Created a sizable 400MB dummy dump file to test offload. With the implemented changes, the offload was completed in 1 minute. Without these updates, the offload would time out after 30 seconds.
 