### PR TITLE
coredump : during startup check for core files and create dump

### DIFF
--- a/dump_manager_bmc.cpp
+++ b/dump_manager_bmc.cpp
@@ -211,6 +211,34 @@ uint32_t Manager::captureDump(Type type,
     return ++lastEntryId;
 }
 
+void Manager::restore()
+{
+    phosphor::dump::bmc_stored::Manager::restore();
+
+    if (std::filesystem::exists(CORE_FILE_DIR) &&
+        std::filesystem::is_directory(CORE_FILE_DIR))
+    {
+        std::vector<std::string> files;
+        for (const auto& file :
+             std::filesystem::directory_iterator(CORE_FILE_DIR))
+        {
+            if (std::filesystem::is_regular_file(file) &&
+                (file.path().filename().string().starts_with("core.")))
+            {
+                // Consider only file name start with "core."
+                files.push_back(file.path().string());
+            }
+        }
+        if (!files.empty())
+        {
+            log<level::INFO>(
+                fmt::format("Core file found, files size {}", files.size())
+                    .c_str());
+            captureDump(Type::ApplicationCored, files);
+        }
+    }
+}
+
 } // namespace bmc
 } // namespace dump
 } // namespace phosphor

--- a/dump_manager_bmc.hpp
+++ b/dump_manager_bmc.hpp
@@ -102,6 +102,10 @@ class Manager :
                      phosphor::dump::OperationStatus status,
                      std::string originatorId,
                      originatorTypes originatorType) override;
+    /** @brief Construct dump d-bus objects from their persisted
+     *        representations.
+     */
+    void restore() override;
 
   private:
     /**  @brief Capture BMC Dump based on the Dump type.


### PR DESCRIPTION
If dump manager crashes core file will be generated but core dump will not be created as the dump service that creates core dump is taking a reset.

Now modified to check for core files at the start of the dump service and capture them in core dump.

Tested:
-----------<crashing dump manager for once >---------- May 25 11:13:51 rain127bmc systemd[1]: Started Process Core Dump (PID 1899/UID 0).
May 25 11:13:51 rain127bmc systemd-coredump[1900]: elfutils disabled, parsing ELF objects not supported
May 25 11:13:51 rain127bmc systemd-coredump[1900]: [LNK] Process 1662 (phosphor-dump-m) of user 0 dumped core.
May 25 11:13:51 rain127bmc systemd[1]: systemd-coredump@3-1899-0.service: Deactivated successfully.
May 25 11:13:52 rain127bmc systemd[1]: xyz.openbmc_project.Dump.Manager.service: Main process exited, code=dumped, status=11/SEGV

----------<after serivce reatart dump file is captured>----------- May 25 11:13:53 rain127bmc phosphor-dump-manager[1910]: Core file found, files size 1
May 25 11:13:53 rain127bmc phosphor-dump-manager[1910]: dump_manager_faultlog restore not implemented
May 25 11:13:53 rain127bmc phosphor-dump-manager[1910]: System dump does not exist in the path (/var/lib/phosphor-debug-collector/preserve/system) to restore May 25 11:13:56 rain127bmc phosphor-dump-manager[2044]: performing dump compression /tmp/BMCDUMP.13BE990.0000004.20230525111353

Change-Id: I4fd6b56c816de89b1625cc33a8001baf6d8ef54c