### PR TITLE
pldm: Use direct libpldm calls to get instanceid

### DIFF
--- a/host-transport-extensions/pldm/common/pldm_utils.cpp
+++ b/host-transport-extensions/pldm/common/pldm_utils.cpp
@@ -35,39 +35,6 @@ int openPLDM()
     return fd;
 }
 
-uint8_t getPLDMInstanceID(uint8_t eid)
-{
-    constexpr auto pldmRequester = "xyz.openbmc_project.PLDM.Requester";
-    constexpr auto pldm = "/xyz/openbmc_project/pldm";
-    uint8_t instanceID = 0;
-
-    try
-    {
-        auto bus = sdbusplus::bus::new_default();
-        auto service = phosphor::dump::getService(bus, pldm, pldmRequester);
-
-        auto method = bus.new_method_call(service.c_str(), pldm, pldmRequester,
-                                          "GetInstanceId");
-        method.append(eid);
-        auto reply = bus.call(method);
-
-        reply.read(instanceID);
-
-        log<level::INFO>(
-            fmt::format("Got instanceId({}) from PLDM eid({})", instanceID, eid)
-                .c_str());
-    }
-    catch (const sdbusplus::exception::SdBusError& e)
-    {
-        log<level::ERR>(
-            fmt::format("Failed to get instance id error({})", e.what())
-                .c_str());
-        elog<NotAllowed>(Reason("Failure in communicating with pldm service, "
-                                "service may not be running"));
-    }
-    return instanceID;
-}
-
 } // namespace pldm
 } // namespace dump
 } // namespace phosphor

--- a/host-transport-extensions/pldm/common/pldm_utils.hpp
+++ b/host-transport-extensions/pldm/common/pldm_utils.hpp
@@ -2,7 +2,16 @@
 
 #pragma once
 
+#include "xyz/openbmc_project/Common/error.hpp"
+
+#include <fmt/core.h>
+#include <libpldm/instance-id.h>
 #include <libpldm/pldm.h>
+
+#include <phosphor-logging/log.hpp>
+
+#include <iostream>
+#include <system_error>
 
 namespace phosphor
 {
@@ -10,7 +19,7 @@ namespace dump
 {
 namespace pldm
 {
-
+using namespace phosphor::logging;
 /**
  * @brief Opens the PLDM file descriptor
  *
@@ -21,13 +30,99 @@ namespace pldm
 int openPLDM();
 
 /**
- * @brief Returns the PLDM instance ID to use for PLDM commands
+ * @brief RAII Class to get pldm instance ID
  *
- * @param[in] eid - The PLDM EID
- *
- * @return uint8_t - The instance ID
  **/
-uint8_t getPLDMInstanceID(uint8_t eid);
+class PLDMInstanceIdDb
+{
+  public:
+    /** @brief Constructor - Initializes and allocates instance Id
+     *  @param[in] tid - the terminus ID the instance ID is associated with
+     *  @return - None
+     */
+    PLDMInstanceIdDb(pldm_tid_t endpointID = 1)
+    {
+        tid = endpointID;
+        int rc = pldm_instance_db_init_default(&pldmInstanceIdDb);
+
+        if (rc)
+        {
+            throw std::system_category().default_error_condition(rc);
+        }
+        allocateInstanceId();
+    }
+
+    /** @brief Destructor - Frees and destroys the instance Id
+     *  @param[in] tid - the terminus ID the instance ID is associated with
+     *  @return - None
+     */
+    ~PLDMInstanceIdDb()
+    {
+        freeInstanceId();
+        int rc = pldm_instance_db_destroy(pldmInstanceIdDb);
+
+        if (rc)
+        {
+            log<level::ERR>(
+                fmt::format("pldm_instance_db_destroy failed, rc= {}", rc)
+                    .c_str());
+        }
+    }
+
+    /** @brief getInstanceID - returns the instance ID allocated for this object
+     *  @param[in] Unused
+     *  @return - uint8_t InstanceID
+     */
+    uint8_t getInstanceID() const
+    {
+        return instanceID;
+    }
+
+  private:
+    /** @brief Allocate an instance ID for the given terminus
+     *  @param[in] tid - the terminus ID the instance ID is associated with
+     *  @return - PLDM instance id or -EAGAIN if there are no available instance
+     *            IDs
+     */
+    void allocateInstanceId()
+    {
+        int rc = pldm_instance_id_alloc(pldmInstanceIdDb, tid, &instanceID);
+
+        if (rc == -EAGAIN)
+        {
+            throw std::runtime_error("No free instance ids");
+        }
+
+        if (rc)
+        {
+            throw std::system_category().default_error_condition(rc);
+        }
+    }
+
+    /** @brief Mark an instance id as unused
+     *  @param[in] Unused
+     */
+    void freeInstanceId()
+    {
+        int rc = pldm_instance_id_free(pldmInstanceIdDb, tid, instanceID);
+
+        if (rc == -EINVAL)
+        {
+            throw std::runtime_error(
+                "Instance ID " + std::to_string(instanceID) + " for TID " +
+                std::to_string(tid) + " was not previously allocated");
+        }
+        if (rc)
+        {
+            throw std::system_category().default_error_condition(rc);
+        }
+    }
+
+    pldm_instance_db* pldmInstanceIdDb = nullptr;
+    // The terminus id for pldm is 1
+    pldm_tid_t tid;
+    pldm_instance_id_t instanceID;
+};
 
 } // namespace pldm
 } // namespace dump


### PR DESCRIPTION

pldm: Use direct libpldm calls to get instanceid

To avoid the latency of DBus calls to get the PLDM Instance Id and also to
correctly coordinate the ID allocations across all the processes, use the
libpldm instance id related library calls

Test: Tested the resource dump download using GUI and delete the same.

Signed-off-by: Deepa Karthikeyan <deepakala.karthikeyan@ibm.com>