### PR TITLE
Add linux trace events

### DIFF
--- a/.shellcheck-ignore
+++ b/.shellcheck-ignore
@@ -30,6 +30,7 @@ tools/dreport.d/plugins.d/obmcconsole
 tools/dreport.d/plugins.d/osrelease
 tools/dreport.d/plugins.d/pldmflightrecorder
 tools/dreport.d/plugins.d/timedate
+tools/dreport.d/plugins.d/traceevents
 tools/dreport.d/plugins.d/top
 tools/dreport.d/plugins.d/uptime
 tools/dreport.d/openpower.d/opdreport

--- a/ffdc
+++ b/ffdc
@@ -30,6 +30,7 @@ declare -a arr=(
       "BMC_dmesg.txt"             "dmesg"
       "BMC_procinfo.txt"          "cat /proc/cpuinfo"
       "BMC_meminfo.txt"           "cat /proc/meminfo"
+      "BMC_traceevents.txt"       "cat /sys/kernel/tracing/trace"
 
 # Copy all content from these directories into directories in the .tar
 # Format: "Directory name" "Directory to copy"

--- a/tools/dreport.d/plugins.d/traceevents
+++ b/tools/dreport.d/plugins.d/traceevents
@@ -1,0 +1,12 @@
+#!/bin/bash
+#
+# config: 2 99
+# @brief: Collect kernel event tracing
+#
+
+. $DREPORT_INCLUDE/functions
+
+desc="Kernel event traces"
+file_name="/sys/kernel/tracing/trace"
+
+add_copy_file "$file_name" "$desc"


### PR DESCRIPTION
Add the output of the linux trace buffer to user dumps, with lowest priority since the file can be large (~10MB).