### PR TITLE
create core dump if core files exit during startup (#59)

### DIFF
--- a/dump-extensions/openpower-dumps/dump_manager_resource.hpp
+++ b/dump-extensions/openpower-dumps/dump_manager_resource.hpp
@@ -55,6 +55,12 @@ class Manager :
      */
     void restore() override;
 
+    /** @brief Perform any post restore operations after claiming
+     *  the bus name. Any new D-Bus dump objects created will be
+     *  notified to the subscribers.
+     */
+    void checkAndInitialize() override {}
+
     /** @brief Notify the resource dump manager about creation of a new dump.
      *  @param[in] dumpId - Id from the source of the dump.
      *  @param[in] size - Size of the dump.

--- a/dump-extensions/openpower-dumps/dump_manager_system.hpp
+++ b/dump-extensions/openpower-dumps/dump_manager_system.hpp
@@ -54,6 +54,12 @@ class Manager :
      */
     void restore() override;
 
+    /** @brief Perform any post restore operations after claiming
+     *  the bus name. Any new D-Bus dump objects created will be
+     *  notified to the subscribers.
+     */
+    void checkAndInitialize() override {}
+
     /** @brief Notify the system dump manager about creation of a new dump.
      *  @param[in] dumpId - Id from the source of the dump.
      *  @param[in] size - Size of the dump.

--- a/dump_manager.hpp
+++ b/dump_manager.hpp
@@ -63,6 +63,12 @@ class Manager : public Iface
      */
     virtual void restore() = 0;
 
+    /** @brief Perform any post restore operations after claiming
+     *  the bus name. Any new D-Bus dump objects created will be
+     *  notified to the subscribers.
+     */
+    virtual void checkAndInitialize() = 0;
+
   protected:
     /** @brief Erase specified entry d-bus object
      *

--- a/dump_manager_bmc.cpp
+++ b/dump_manager_bmc.cpp
@@ -140,6 +140,37 @@ void Manager::createEntry(const uint32_t id, const std::string objPath,
     }
 }
 
+void Manager::checkAndInitialize()
+{
+    checkAndCreateCoreDump();
+}
+
+void Manager::checkAndCreateCoreDump()
+{
+    if (std::filesystem::exists(CORE_FILE_DIR) &&
+        std::filesystem::is_directory(CORE_FILE_DIR))
+    {
+        std::vector<std::string> files;
+        for (const auto& file :
+             std::filesystem::directory_iterator(CORE_FILE_DIR))
+        {
+            if (std::filesystem::is_regular_file(file) &&
+                (file.path().filename().string().starts_with("core.")))
+            {
+                // Consider only file name start with "core."
+                files.push_back(file.path().string());
+            }
+        }
+        if (!files.empty())
+        {
+            log<level::INFO>(
+                fmt::format("Core file found, files size {}", files.size())
+                    .c_str());
+            captureDump(Type::ApplicationCored, files);
+        }
+    }
+}
+
 uint32_t Manager::captureDump(Type type,
                               const std::vector<std::string>& fullPaths)
 {

--- a/dump_manager_bmc.hpp
+++ b/dump_manager_bmc.hpp
@@ -103,6 +103,12 @@ class Manager :
                      std::string originatorId,
                      originatorTypes originatorType) override;
 
+    /** @brief Perform any post restore operations after claiming
+     *  the bus name. Any new D-Bus dump objects created will be
+     *  notified to the subscribers.
+     */
+    void checkAndInitialize() override;
+
   private:
     /**  @brief Capture BMC Dump based on the Dump type.
      *  @param[in] type - Type of the Dump.
@@ -115,8 +121,11 @@ class Manager :
     /** @brief Flag to reject user intiated dump if a dump is in progress*/
     // TODO: https://github.com/openbmc/phosphor-debug-collector/issues/19
     static bool fUserDumpInProgress;
-};
 
+    /** @brief Check if any core files present and create BMC core dump
+     */
+    void checkAndCreateCoreDump();
+};
 } // namespace bmc
 } // namespace dump
 } // namespace phosphor

--- a/dump_manager_bmcstored.hpp
+++ b/dump_manager_bmcstored.hpp
@@ -99,6 +99,12 @@ class Manager : public phosphor::dump::Manager
      */
     void restore() override;
 
+    /** @brief Perform any post restore operations after claiming
+     *  the bus name. Any new D-Bus dump objects created will be
+     *  notified to the subscribers.
+     */
+    void checkAndInitialize() override {}
+
     /** @brief sdbusplus Dump event loop */
     EventPtr eventLoop;
 

--- a/dump_manager_faultlog.hpp
+++ b/dump_manager_faultlog.hpp
@@ -77,6 +77,12 @@ class Manager :
     sdbusplus::message::object_path
         createDump(phosphor::dump::DumpCreateParams params) override;
 
+    /** @brief Perform any post restore operations after claiming
+     *  the bus name. Any new D-Bus dump objects created will be
+     *  notified to the subscribers.
+     */
+    void checkAndInitialize() override {}
+
   private:
     /** @brief Path to the dump file*/
     std::string dumpDir;

--- a/dump_manager_main.cpp
+++ b/dump_manager_main.cpp
@@ -99,6 +99,12 @@ int main()
         // Daemon is all set up so claim the busname now.
         bus.request_name(DUMP_BUSNAME);
 
+        // check and initialize
+        for (auto& dmpMgr : dumpMgrList)
+        {
+            dmpMgr->checkAndInitialize();
+        }
+
         auto rc = sd_event_loop(eventP.get());
         if (rc < 0)
         {


### PR DESCRIPTION
If dump manager crashes core file will be generated but core dump will not be created as the dump service that creates core dump is taking a reset.

Now modified to check for core files at the start of the dump service and capture them in core dump.

Tested:
May 27 10:51:32 ever6bmc systemd-coredump[11886]: [🡕] Process 11697 (phosphor-dump-m) of user 0 dumped core.
May 27 10:51:32 ever6bmc systemd[1]: systemd-coredump@18-11885-0.service: Deactivated successfully.
May 27 10:51:33 ever6bmc phosphor-dump-monitor[11715]: Failed to create dump: sd_bus_call noreply: org.freedesktop.DBus.Error.NoReply: Remote peer disconnected
May 27 10:51:33 ever6bmc systemd[1]: xyz.openbmc_project.Dump.Manager.service: Main process exited, code=dumped, status=11/SEGV
May 27 10:51:33 ever6bmc systemd[1]: xyz.openbmc_project.Dump.Manager.service: Failed with result 'core-dump'.

May 27 10:51:34 ever6bmc phosphor-dump-manager[11895]: Core file found, files size 20
May 27 10:51:34 ever6bmc systemd[1]: Starting Phosphor Dump Manager...

May 27 10:51:39 ever6bmc phosphor-dump-manager[11996]: performing dump compression /tmp/BMCDUMP.EV00003.00000002.20220527105134 May 27 10:51:40 ever6bmc phosphor-dump-manager[11996]: Adding Dump Header :/usr/share/dreport.d/include.d/gendumpheader
May 27 10:51:44 ever6bmc phosphor-dump-manager[11996]: Fri May 27 10:51:44 UTC 2022 Report is available in /var/lib/phosphor-debug-collector/dumps/2 May 27 10:51:44 ever6bmc phosphor-dump-manager[11896]: Fri May 27 10:51:44 UTC 2022 Successfully completed
May 27 10:51:44 ever6bmc pvm_dump_offload[11104]: Watch interfaceAdded path (/xyz/openbmc_project/dump/bmc/entry/2)


Change-Id: Icd3dcb84d21506f01770f7272d8ad851a2d6d122