### PR TITLE
Fix duplicate InterfacesRemoved signal

### DIFF
--- a/bmc_dump_entry.hpp
+++ b/bmc_dump_entry.hpp
@@ -64,7 +64,7 @@ class Entry :
         phosphor::dump::bmc_stored::Entry(bus, objPath.c_str(), dumpId,
                                           timeStamp, fileSize, file, status,
                                           originatorId, originatorType, parent),
-        EntryIfaces(bus, objPath.c_str(), EntryIfaces::action::defer_emit)
+        EntryIfaces(bus, objPath.c_str(), EntryIfaces::action::emit_no_signals)
     {
         // Emit deferred signal.
         this->phosphor::dump::bmc::EntryIfaces::emit_object_added();

--- a/bmcstored_dump_entry.hpp
+++ b/bmcstored_dump_entry.hpp
@@ -63,7 +63,7 @@ class Entry : public phosphor::dump::Entry, public FileIfaces
           originatorTypes originType, phosphor::dump::Manager& parent) :
         phosphor::dump::Entry(bus, objPath.c_str(), dumpId, timeStamp, fileSize,
                               status, originId, originType, parent),
-        FileIfaces(bus, objPath.c_str(), FileIfaces::action::defer_emit)
+        FileIfaces(bus, objPath.c_str())
     {
         offloadInProgress = false;
         path(file);

--- a/dump-extensions/openpower-dumps/hardware_dump_entry.hpp
+++ b/dump-extensions/openpower-dumps/hardware_dump_entry.hpp
@@ -61,7 +61,7 @@ class Entry :
         phosphor::dump::bmc_stored::Entry(bus, objPath.c_str(), dumpId,
                                           timeStamp, fileSize, file, status,
                                           parent),
-        EntryIfaces(bus, objPath.c_str(), true)
+        EntryIfaces(bus, objPath.c_str(), EntryIfaces::action::emit_no_signals)
     {
         // Emit deferred signal.
         this->openpower::dump::hardware::EntryIfaces::emit_object_added();

--- a/dump-extensions/openpower-dumps/host_dump_entry.hpp
+++ b/dump-extensions/openpower-dumps/host_dump_entry.hpp
@@ -65,7 +65,7 @@ class Entry :
                                           timeStamp, fileSize, file, status,
                                           originatorId, originatorType, parent),
         EntryIfaces<T>(bus, objPath.c_str(),
-                       EntryIfaces<T>::action::emit_object_added)
+                       EntryIfaces<T>::action::emit_no_signals)
     {
         // Emit deferred signal.
         this->openpower::dump::hostdump::EntryIfaces<T>::emit_object_added();

--- a/dump-extensions/openpower-dumps/sbe_dump_entry.hpp
+++ b/dump-extensions/openpower-dumps/sbe_dump_entry.hpp
@@ -61,7 +61,7 @@ class Entry :
         phosphor::dump::bmc_stored::Entry(bus, objPath.c_str(), dumpId,
                                           timeStamp, fileSize, file, status,
                                           parent),
-        EntryIfaces(bus, objPath.c_str(), true)
+        EntryIfaces(bus, objPath.c_str(), EntryIfaces::action::emit_no_signals)
     {
         // Emit deferred signal.
         this->openpower::dump::sbe::EntryIfaces::emit_object_added();


### PR DESCRIPTION
When the bmc dump is deleted, it emits two Interfaces Removed signal on the bmc dump entry object.

bmc_stored::Entry inherits phosphor_dump_entry and other interfaces which are inherited from sdbusplus object class who emit Interfaces Remvoved signal. bm_stored::Entry is further inherited in other classes. So adding a virtual inheritance resolved the duplicate signals emitted.

Tested and found only one InterfacesRemoved signal emitted on bmc dump deletion. And tested the other dump creation and deletion and it works as expected.