### PR TITLE
Failing unit id was wrong for SBE dumps

### DIFF
--- a/dump-extensions/openpower-dumps/dump_manager_hostdump.hpp
+++ b/dump-extensions/openpower-dumps/dump_manager_hostdump.hpp
@@ -106,7 +106,6 @@ class Manager :
     {
         // Check dump policy
         util::isOPDumpsEnabled();
-        uint8_t dumpType = 0;
         uint64_t eid = 0;
         uint64_t failingUnit = 0;
 


### PR DESCRIPTION
An additional local variable was preventing the correct dump type to be passed to the function extracting the failing unit id.

Tested:
 busctl --verbose call xyz.openbmc_project.Dump.Manager /xyz/openbmc_project/dump/sbe xyz.openbmc_project.Dump.Create CreateDump a{sv} 2 "com.ibm.Dump.Create.CreateParameters.ErrorLogId" t 0xDEADBEEF "com.ibm.Dump.Create.CreateParameters.FailingUnitId" t 0
MESSAGE "o" {
        OBJECT_PATH "/xyz/openbmc_project/dump/sbe/entry/30000003";
};

Sep 04 20:48:50 rain104bmc phosphor-dump-manager[2870]: Creating dump with dumpPath(/var/lib/phosphor-debug-collector/sbedump/30000003) id(30000003) available space(102400) eid(deadbeef) dump type(10) failing unit(0)
Sep 04 20:48:50 rain104bmc phosphor-dump-manager[2882]: Collecting SBE dump: path=/tmp/dump_30000003_1693860530/plat_dump, id=30000003, chip position=0

root@rain104bmc:~# busctl --verbose call xyz.openbmc_project.Dump.Manager /xyz/openbmc_project/dump/sbe xyz.openbmc_project.Dump.Create CreateDump a{sv} 2 "com.ibm.Dump.Create.CreateParameters.ErrorLogId" t 0xDEADBEEF "com.ibm.Dump.Create.CreateParameters.FailingUnitId" t 1
MESSAGE "o" {
        OBJECT_PATH "/xyz/openbmc_project/dump/sbe/entry/30000005";
};

Sep 04 20:49:14 rain104bmc phosphor-dump-manager[3169]: Creating dump with dumpPath(/var/lib/phosphor-debug-collector/sbedump/30000005) id(30000005) available space(102400) eid(deadbeef) dump type(10) failing unit(1)
Sep 04 20:49:14 rain104bmc phosphor-dump-manager[3181]: Collecting SBE dump: path=/tmp/dump_30000005_1693860554/plat_dump, id=30000005, chip position=1