### PR TITLE
Revert "Merge pull request #118 from deepakala-k/virtual_inherit"

### DIFF
--- a/bmc_dump_entry.hpp
+++ b/bmc_dump_entry.hpp
@@ -64,7 +64,7 @@ class Entry :
         phosphor::dump::bmc_stored::Entry(bus, objPath.c_str(), dumpId,
                                           timeStamp, fileSize, file, status,
                                           originatorId, originatorType, parent),
-        EntryIfaces(bus, objPath.c_str(), EntryIfaces::action::emit_no_signals)
+        EntryIfaces(bus, objPath.c_str(), EntryIfaces::action::defer_emit)
     {
         // Emit deferred signal.
         this->phosphor::dump::bmc::EntryIfaces::emit_object_added();

--- a/bmcstored_dump_entry.hpp
+++ b/bmcstored_dump_entry.hpp
@@ -63,7 +63,7 @@ class Entry : public phosphor::dump::Entry, public FileIfaces
           originatorTypes originType, phosphor::dump::Manager& parent) :
         phosphor::dump::Entry(bus, objPath.c_str(), dumpId, timeStamp, fileSize,
                               status, originId, originType, parent),
-        FileIfaces(bus, objPath.c_str())
+        FileIfaces(bus, objPath.c_str(), FileIfaces::action::defer_emit)
     {
         offloadInProgress = false;
         path(file);

--- a/dump-extensions/openpower-dumps/hardware_dump_entry.hpp
+++ b/dump-extensions/openpower-dumps/hardware_dump_entry.hpp
@@ -61,7 +61,7 @@ class Entry :
         phosphor::dump::bmc_stored::Entry(bus, objPath.c_str(), dumpId,
                                           timeStamp, fileSize, file, status,
                                           parent),
-        EntryIfaces(bus, objPath.c_str(), EntryIfaces::action::emit_no_signals)
+        EntryIfaces(bus, objPath.c_str(), true)
     {
         // Emit deferred signal.
         this->openpower::dump::hardware::EntryIfaces::emit_object_added();

--- a/dump-extensions/openpower-dumps/host_dump_entry.hpp
+++ b/dump-extensions/openpower-dumps/host_dump_entry.hpp
@@ -65,7 +65,7 @@ class Entry :
                                           timeStamp, fileSize, file, status,
                                           originatorId, originatorType, parent),
         EntryIfaces<T>(bus, objPath.c_str(),
-                       EntryIfaces<T>::action::emit_no_signals)
+                       EntryIfaces<T>::action::emit_object_added)
     {
         // Emit deferred signal.
         this->openpower::dump::hostdump::EntryIfaces<T>::emit_object_added();

--- a/dump-extensions/openpower-dumps/sbe_dump_entry.hpp
+++ b/dump-extensions/openpower-dumps/sbe_dump_entry.hpp
@@ -61,7 +61,7 @@ class Entry :
         phosphor::dump::bmc_stored::Entry(bus, objPath.c_str(), dumpId,
                                           timeStamp, fileSize, file, status,
                                           parent),
-        EntryIfaces(bus, objPath.c_str(), EntryIfaces::action::emit_no_signals)
+        EntryIfaces(bus, objPath.c_str(), true)
     {
         // Emit deferred signal.
         this->openpower::dump::sbe::EntryIfaces::emit_object_added();

--- a/dump_utils.hpp
+++ b/dump_utils.hpp
@@ -36,7 +36,7 @@ struct EventDeleter
 {
     void operator()(sd_event* event) const
     {
-        event = sd_event_unref(event);
+        sd_event_unref(event);
     }
 };
 using EventPtr = std::unique_ptr<sd_event, EventDeleter>;


### PR DESCRIPTION
This reverts commit 8e3c7d91e37744e2c3d9d3538fd1efd2bc07ac22, reversing changes made to b2e5fda260d8243c530c05074390db65709f9738.

It is found that the object mapper is not updated with the dbus objects added/ removed as the expected signal is not generated. So revert the commit.