### PR TITLE
1060: Handle exceptions thrown during checkAndInitialize (#120)

### DIFF
--- a/bmc_dump_entry.hpp
+++ b/bmc_dump_entry.hpp
@@ -32,8 +32,8 @@ class Manager;
  *  xyz.openbmc_project.Dump.Entry DBus API
  */
 class Entry :
-    virtual public EntryIfaces,
-    virtual public phosphor::dump::bmc_stored::Entry
+    virtual public phosphor::dump::bmc_stored::Entry,
+    virtual public EntryIfaces
 {
   public:
     Entry() = delete;
@@ -61,10 +61,10 @@ class Entry :
           const std::filesystem::path& file,
           phosphor::dump::OperationStatus status, std::string originatorId,
           originatorTypes originatorType, phosphor::dump::Manager& parent) :
-        EntryIfaces(bus, objPath.c_str(), EntryIfaces::action::defer_emit),
         phosphor::dump::bmc_stored::Entry(bus, objPath.c_str(), dumpId,
                                           timeStamp, fileSize, file, status,
-                                          originatorId, originatorType, parent)
+                                          originatorId, originatorType, parent),
+        EntryIfaces(bus, objPath.c_str(), EntryIfaces::action::defer_emit)
     {
         // Emit deferred signal.
         this->phosphor::dump::bmc::EntryIfaces::emit_object_added();

--- a/bmcstored_dump_entry.hpp
+++ b/bmcstored_dump_entry.hpp
@@ -63,7 +63,7 @@ class Entry : public phosphor::dump::Entry, public FileIfaces
           originatorTypes originType, phosphor::dump::Manager& parent) :
         phosphor::dump::Entry(bus, objPath.c_str(), dumpId, timeStamp, fileSize,
                               status, originId, originType, parent),
-        FileIfaces(bus, objPath.c_str())
+        FileIfaces(bus, objPath.c_str(), FileIfaces::action::defer_emit)
     {
         offloadInProgress = false;
         path(file);

--- a/dump-extensions/openpower-dumps/hardware_dump_entry.hpp
+++ b/dump-extensions/openpower-dumps/hardware_dump_entry.hpp
@@ -31,8 +31,8 @@ class Manager;
  *  xyz.openbmc_project.Dump.Entry DBus API
  */
 class Entry :
-    virtual public EntryIfaces,
-    virtual public phosphor::dump::bmc_stored::Entry
+    virtual public phosphor::dump::bmc_stored::Entry,
+    virtual public EntryIfaces
 {
   public:
     Entry() = delete;
@@ -58,10 +58,10 @@ class Entry :
           const std::filesystem::path& file,
           phosphor::dump::OperationStatus status,
           phosphor::dump::Manager& parent) :
-        EntryIfaces(bus, objPath.c_str(), true),
         phosphor::dump::bmc_stored::Entry(bus, objPath.c_str(), dumpId,
                                           timeStamp, fileSize, file, status,
-                                          parent)
+                                          parent),
+        EntryIfaces(bus, objPath.c_str(), true)
     {
         // Emit deferred signal.
         this->openpower::dump::hardware::EntryIfaces::emit_object_added();

--- a/dump-extensions/openpower-dumps/host_dump_entry.hpp
+++ b/dump-extensions/openpower-dumps/host_dump_entry.hpp
@@ -32,8 +32,8 @@ using EntryIfaces = sdbusplus::server::object_t<T>;
  */
 template <typename T>
 class Entry :
-    virtual public EntryIfaces<T>,
-    virtual public phosphor::dump::bmc_stored::Entry
+    virtual public phosphor::dump::bmc_stored::Entry,
+    virtual public EntryIfaces<T>
 {
   public:
     Entry() = delete;
@@ -61,11 +61,11 @@ class Entry :
           const std::filesystem::path& file,
           phosphor::dump::OperationStatus status, std::string originatorId,
           originatorTypes originatorType, phosphor::dump::Manager& parent) :
-        EntryIfaces<T>(bus, objPath.c_str(),
-                       EntryIfaces<T>::action::emit_object_added),
         phosphor::dump::bmc_stored::Entry(bus, objPath.c_str(), dumpId,
                                           timeStamp, fileSize, file, status,
-                                          originatorId, originatorType, parent)
+                                          originatorId, originatorType, parent),
+        EntryIfaces<T>(bus, objPath.c_str(),
+                       EntryIfaces<T>::action::emit_object_added)
     {
         // Emit deferred signal.
         this->openpower::dump::hostdump::EntryIfaces<T>::emit_object_added();

--- a/dump-extensions/openpower-dumps/resource_dump_entry.hpp
+++ b/dump-extensions/openpower-dumps/resource_dump_entry.hpp
@@ -31,7 +31,7 @@ class Manager;
  *  A concrete implementation for the
  *  com::ibm::Dump::Entry::Resource DBus API
  */
-class Entry : virtual public EntryIfaces, virtual public phosphor::dump::Entry
+class Entry : virtual public phosphor::dump::Entry, virtual public EntryIfaces
 {
   public:
     Entry() = delete;
@@ -65,9 +65,9 @@ class Entry : virtual public EntryIfaces, virtual public phosphor::dump::Entry
           phosphor::dump::OperationStatus status, std::string originatorId,
           originatorTypes originatorType, const std::string& baseEntryPath,
           phosphor::dump::Manager& parent, bool emitSignal = true) :
-        EntryIfaces(bus, objPath.c_str(), EntryIfaces::action::defer_emit),
         phosphor::dump::Entry(bus, objPath.c_str(), dumpId, timeStamp, dumpSize,
                               status, originatorId, originatorType, parent),
+        EntryIfaces(bus, objPath.c_str(), EntryIfaces::action::defer_emit),
         baseEntryPath(baseEntryPath)
     {
         sourceDumpId(sourceId);

--- a/dump-extensions/openpower-dumps/sbe_dump_entry.hpp
+++ b/dump-extensions/openpower-dumps/sbe_dump_entry.hpp
@@ -31,8 +31,8 @@ class Manager;
  *  xyz.openbmc_project.Dump.Entry DBus API
  */
 class Entry :
-    virtual public EntryIfaces,
-    virtual public phosphor::dump::bmc_stored::Entry
+    virtual public phosphor::dump::bmc_stored::Entry,
+    virtual public EntryIfaces
 {
   public:
     Entry() = delete;
@@ -58,10 +58,10 @@ class Entry :
           const std::filesystem::path& file,
           phosphor::dump::OperationStatus status,
           phosphor::dump::Manager& parent) :
-        EntryIfaces(bus, objPath.c_str(), true),
         phosphor::dump::bmc_stored::Entry(bus, objPath.c_str(), dumpId,
                                           timeStamp, fileSize, file, status,
-                                          parent)
+                                          parent),
+        EntryIfaces(bus, objPath.c_str(), true)
     {
         // Emit deferred signal.
         this->openpower::dump::sbe::EntryIfaces::emit_object_added();

--- a/dump-extensions/openpower-dumps/system_dump_entry.hpp
+++ b/dump-extensions/openpower-dumps/system_dump_entry.hpp
@@ -28,7 +28,7 @@ class Manager;
  *  @details A concrete implementation for the
  *  xyz.openbmc_project.Dump.Entry DBus API
  */
-class Entry : virtual public EntryIfaces, virtual public phosphor::dump::Entry
+class Entry : virtual public phosphor::dump::Entry, virtual public EntryIfaces
 {
   public:
     Entry() = delete;
@@ -59,9 +59,9 @@ class Entry : virtual public EntryIfaces, virtual public phosphor::dump::Entry
           phosphor::dump::OperationStatus status, std::string originatorId,
           originatorTypes originatorType, const std::string& baseEntryPath,
           phosphor::dump::Manager& parent, bool emitSignal = true) :
-        EntryIfaces(bus, objPath.c_str(), EntryIfaces::action::defer_emit),
         phosphor::dump::Entry(bus, objPath.c_str(), dumpId, timeStamp, dumpSize,
                               status, originatorId, originatorType, parent),
+        EntryIfaces(bus, objPath.c_str(), EntryIfaces::action::defer_emit),
         baseEntryPath(baseEntryPath)
     {
         sourceDumpId(sourceId);


### PR DESCRIPTION
#### Handle exceptions thrown during checkAndInitialize (#120)
```
If dump manager crashes core file will be generated but core dump will
not be created as the dump service that creates core dump is taking a
reset. We check for core files at the start of the dump service and
capture them in core dump.If there was an exception while capturing the
dump it was unhandled

Fix:
Added exception handling for the above scenario.

Signed-off-by: Deepa Karthikeyan <deepakala.karthikeyan@ibm.com>
```