### PR TITLE
ramoops: generate error log when ramoops detected

### DIFF
--- a/ramoops_manager.cpp
+++ b/ramoops_manager.cpp
@@ -4,6 +4,9 @@
 
 #include <fmt/core.h>
 
+#include <phosphor-logging/elog-errors.hpp>
+#include <phosphor-logging/lg2.hpp>
+#include <sdbusplus/bus.hpp>
 #include <sdbusplus/exception.hpp>
 
 #include <filesystem>
@@ -25,10 +28,48 @@ Manager::Manager(const std::string& filePath)
         return;
     }
 
+    // Create error to notify user that a ramoops has been detected
+    createError();
+
     std::vector<std::string> files;
     files.push_back(filePath);
 
     createHelper(files);
+}
+
+void Manager::createError()
+{
+    try
+    {
+        std::map<std::string, std::string> additionalData;
+
+        // Always add the _PID on for some extra logging debug
+        additionalData.emplace("_PID", std::to_string(getpid()));
+
+        auto bus = sdbusplus::bus::new_default();
+        auto method = bus.new_method_call(
+            "xyz.openbmc_project.Logging", "/xyz/openbmc_project/logging",
+            "xyz.openbmc_project.Logging.Create", "Create");
+
+        method.append("xyz.openbmc_project.Dump.Error.Ramoops",
+                      sdbusplus::server::xyz::openbmc_project::logging::Entry::
+                          Level::Error,
+                      additionalData);
+        auto resp = bus.call(method);
+    }
+    catch (const sdbusplus::exception_t& e)
+    {
+        lg2::error(
+            "sdbusplus D-Bus call exception, error {ERROR} trying to create "
+            "an error for ramoops detection",
+            "ERROR", e);
+        // This is a best-effort logging situation so don't throw anything
+    }
+    catch (const std::exception& e)
+    {
+        lg2::error("D-bus call exception: {ERROR}", "ERROR", e);
+        // This is a best-effort logging situation so don't throw anything
+    }
 }
 
 void Manager::createHelper(const std::vector<std::string>& files)

--- a/ramoops_manager.hpp
+++ b/ramoops_manager.hpp
@@ -42,6 +42,11 @@ class Manager
      *  @param [in] files - ramoops files list
      */
     void createHelper(const std::vector<std::string>& files);
+
+    /** @brief Create an error indicating ramoops was found
+     *
+     */
+    void createError();
 };
 
 } // namespace ramoops


### PR DESCRIPTION
A ramoops being detected is a critical event for a BMC based system. It indicates the BMC had an unexpected reboot because of a kernel panic. Ensure a log is reported so the user of the system knows to look for a BMC dump with the debug information.

Tested:
- Manually created some files in /var/lib/systemd/pstore/ and ran the ramoops application and verified the expected log was created.

Upstream: https://gerrit.openbmc.org/c/openbmc/phosphor-debug-collector/+/67677

Change-Id: Id1162fa0cca72e5dcc8cf59e75bd298d2ddada2e