### PR TITLE
Add support for Memory Buffer SBE dump

### DIFF
--- a/dump-extensions/openpower-dumps/dump-extensions.cpp
+++ b/dump-extensions/openpower-dumps/dump-extensions.cpp
@@ -121,6 +121,24 @@ void loadExtensions(sdbusplus::bus::bus& bus,
         bus, event, SBE_DUMP_OBJPATH, SBE_DUMP_OBJ_ENTRY, SBE_DUMP_START_ID,
         SBE_DUMP_PATH, "sbedump", SBE_DUMP_MAX_SIZE, SBE_DUMP_MIN_SPACE_REQD,
         SBE_DUMP_TOTAL_SIZE, openpower::dump::util::SBE_DUMP_TYPE_SBE));
+
+    try
+    {
+        std::filesystem::create_directories(MSBE_DUMP_PATH);
+    }
+    catch (std::exception& e)
+    {
+        log<level::ERR>(fmt::format("Failed to create SBE dump directory({})",
+                                    MSBE_DUMP_PATH)
+                            .c_str());
+        throw std::runtime_error("Failed to create SBE dump directory");
+    }
+
+    dumpList.push_back(std::make_unique<openpower::dump::hostdump::Manager<
+                           sdbusplus::com::ibm::Dump::Entry::server::SBE>>(
+        bus, event, MSBE_DUMP_OBJPATH, MSBE_DUMP_OBJ_ENTRY, MSBE_DUMP_START_ID,
+        MSBE_DUMP_PATH, "sbedump", MSBE_DUMP_MAX_SIZE, MSBE_DUMP_MIN_SPACE_REQD,
+        MSBE_DUMP_TOTAL_SIZE, openpower::dump::util::SBE_DUMP_TYPE_MSBE));
 }
 } // namespace dump
 } // namespace phosphor

--- a/dump-extensions/openpower-dumps/meson.build
+++ b/dump-extensions/openpower-dumps/meson.build
@@ -100,6 +100,30 @@ opconf_data.set('SBE_DUMP_TOTAL_SIZE', get_option('SBE_DUMP_TOTAL_SIZE'),
 opconf_data.set('SBE_DUMP_START_ID', get_option('SBE_DUMP_START_ID'),
                description : 'Starting id of SBE dump'
             )
+opconf_data.set_quoted('MSBE_DUMP_OBJPATH', get_option('MSBE_DUMP_OBJPATH'),
+                      description : 'The memory buffer SBE dump manager D-Bus path'
+                    )
+opconf_data.set_quoted('MSBE_DUMP_OBJ_ENTRY', get_option('MSBE_DUMP_OBJ_ENTRY'),
+                      description : 'The memory buffer SBE dump entry D-Bus object path'
+                    )
+opconf_data.set_quoted('MSBE_DUMP_TMP_FILE_DIR', get_option('MSBE_DUMP_TMP_FILE_DIR'),
+                      description : 'Directory where memory buffer SBE dump pieces are stored for packaging'
+                    )
+opconf_data.set_quoted('MSBE_DUMP_PATH', get_option('MSBE_DUMP_PATH'),
+                     description : 'Directory where memory buffer SBE dumps are placed'
+             )
+opconf_data.set('MSBE_DUMP_MAX_SIZE', get_option('MSBE_DUMP_MAX_SIZE'),
+               description : 'Maximum size of one memory buffer SBE dump in kilo bytes'
+             )
+opconf_data.set('MSBE_DUMP_MIN_SPACE_REQD', get_option('MSBE_DUMP_MIN_SPACE_REQD'),
+               description : 'Minimum space required for one memory buffer SBE dump in kilo bytes'
+             )
+opconf_data.set('MSBE_DUMP_TOTAL_SIZE', get_option('MSBE_DUMP_TOTAL_SIZE'),
+               description : 'Total size of the dump in kilo bytes'
+            )
+opconf_data.set('MSBE_DUMP_START_ID', get_option('MSBE_DUMP_START_ID'),
+               description : 'Starting id of memory buffer SBE dump'
+            )
 opconf_data.set_quoted('SYS_DUMP_FILENAME_REGEX', get_option('SYS_DUMP_FILENAME_REGEX'),
                       description: 'System Dump filename format'
             )

--- a/dump-extensions/openpower-dumps/op_dump_util.cpp
+++ b/dump-extensions/openpower-dumps/op_dump_util.cpp
@@ -187,7 +187,8 @@ void extractDumpCreateParams(const phosphor::dump::DumpCreateParams& params,
         eid = 0;
     }
 
-    if ((dumpType == SBE_DUMP_TYPE_HARDWARE) || (dumpType == SBE_DUMP_TYPE_SBE))
+    if ((dumpType == SBE_DUMP_TYPE_HARDWARE) ||
+        (dumpType == SBE_DUMP_TYPE_SBE) || (dumpType == SBE_DUMP_TYPE_MSBE))
     {
         iter = params.find(sdbusplus::com::ibm::Dump::server::Create::
                                convertCreateParametersToString(

--- a/dump-extensions/openpower-dumps/op_dump_util.hpp
+++ b/dump-extensions/openpower-dumps/op_dump_util.hpp
@@ -13,6 +13,7 @@ namespace util
 constexpr auto SBE_DUMP_TYPE_HOSTBOOT = 0x5;
 constexpr auto SBE_DUMP_TYPE_HARDWARE = 0x1;
 constexpr auto SBE_DUMP_TYPE_SBE = 0xA;
+constexpr auto SBE_DUMP_TYPE_MSBE = 0xB;
 
 /** @brief Check whether OpenPOWER dumps are enabled
  *

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -271,6 +271,47 @@ option('SBE_DUMP_START_ID', type : 'integer',
         description : 'Starting id of SBE Dump'
       )
 
+# Memory buffer SBE dump options
+
+option('MSBE_DUMP_OBJPATH', type : 'string',
+        value : '/xyz/openbmc_project/dump/msbe',
+        description : 'The memory buffer SBE dump manager D-Bus object path'
+      )
+
+option('MSBE_DUMP_OBJ_ENTRY', type : 'string',
+        value : '/xyz/openbmc_project/dump/msbe/entry',
+        description : 'The memory buffer SBE dump entry D-Bus object path'
+      )
+
+option('MSBE_DUMP_TMP_FILE_DIR', type : 'string',
+        value : '/tmp/openpower-dumps/msbe',
+        description : 'Directory where memory buffer SBE dump pieces are stored for packaging'
+      )
+
+option('MSBE_DUMP_PATH', type : 'string',
+        value : '/var/lib/phosphor-debug-collector/msbedump/',
+        description : 'Directory where memory buffer SBE dumps are placed'
+      )
+
+option('MSBE_DUMP_MAX_SIZE', type : 'integer',
+        value : 102400,
+        description : 'Maximum size of one memory buffer SBE dump in kilo bytes'
+      )
+
+option('MSBE_DUMP_MIN_SPACE_REQD', type : 'integer',
+        value : 81920,
+        description : 'Minimum space required for one memory buffer SBE dump in kilo bytes'
+      )
+
+option('MSBE_DUMP_TOTAL_SIZE', type : 'integer',
+        value : 409600,
+        description : 'Total size of the memory buffer SBE dump in kilo bytes'
+      )
+option('MSBE_DUMP_START_ID', type : 'integer',
+        value : 40000000,
+        description : 'Starting id of memory buffer SBE Dump'
+      )
+
 option('BMC_DUMP_FILENAME_REGEX', type: 'string',
         value: 'obmcdump_([0-9]+)_([0-9]+).([a-zA-Z0-9]+)',
         description : 'BMC dump file format'


### PR DESCRIPTION
The memory buffer SBE dump is similar to the dump collected from the processor SBE, but with a different method. This dump is collected during a critical failure on the SBE and contain specific debug data.

This commit provides an interface calling the dump collection so other services can invoke dump collection when there is an SBE failure detected.