### PR TITLE
Modify plugin to capture all journal data during elog/core dump

### DIFF
--- a/tools/dreport.d/plugins.d/journalpretty
+++ b/tools/dreport.d/plugins.d/journalpretty
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# config: 24 10
+# config: 1234 10
 # @brief: Collect Journal pretty log information.
 #
 


### PR DESCRIPTION
This change was is in our 1020-1040 release but we lost it during our 1050 rebase. Pull back into 1060 and pending must-fix we'll get into 1050 as well.

We can't upstream because systems with smaller flashes do not want this and finding a way to dynamically configure this file is complicated.