### PR TITLE
Keep common entry path for all SBE dump types

### DIFF
--- a/meson_options.txt
+++ b/meson_options.txt
@@ -279,7 +279,7 @@ option('MSBE_DUMP_OBJPATH', type : 'string',
       )
 
 option('MSBE_DUMP_OBJ_ENTRY', type : 'string',
-        value : '/xyz/openbmc_project/dump/msbe/entry',
+        value : '/xyz/openbmc_project/dump/sbe/entry',
         description : 'The memory buffer SBE dump entry D-Bus object path'
       )
 


### PR DESCRIPTION
The SBE dumps from processor and OCMB are differentiated with dump ID but presented outside as SBE dumps, keeping the common path for all types of SBE dumps.

Tests:
Created SBE dump 
- Listed
- Offloaded
- Deleted
from both the redfish command and GUI