### PR TITLE
Fix maximum number of processors

### DIFF
--- a/dump-extensions/openpower-dumps/op_dump_util.cpp
+++ b/dump-extensions/openpower-dumps/op_dump_util.cpp
@@ -149,7 +149,7 @@ void extractDumpCreateParams(const phosphor::dump::DumpCreateParams& params,
     eid = 0;
     failingUnit = 0;
 
-    constexpr auto MAX_FAILING_UNIT = 0x20;
+    constexpr auto MAX_FAILING_UNIT = 0xFF;
     constexpr auto MAX_ERROR_LOG_ID = 0xFFFFFFFF;
 
     // get error log id


### PR DESCRIPTION
With OCMB also has SBE and the failing unit id of the memory buffer can be more than 32, keeping a higher maximum number

Without fix:
root@ever6bmc:~# busctl --verbose call org.open_power.Dump.Manager /org/openpower/dump xyz.openbmc_project.Dump.Create CreateDump a{sv} 3  "com.ibm.Dump.Create.CreateParameters.DumpType" s "com.ibm.Dump.Create.DumpType.MemoryBufferSBE" "com.ibm.Dump.Create.CreateParameters.ErrorLogId" t 0xDEADBEEF "com.ibm.Dump.Create.CreateParameters.FailingUnitId" t 34
Call failed: Invalid argument was given.

with fix
root@ever6bmc:~# busctl --verbose call org.open_power.Dump.Manager /org/openpower/dump xyz.openbmc_project.Dump.Create CreateDump a{sv} 3  "com.ibm.Dump.Create.CreateParameters.DumpType" s "com.ibm.Dump.Create.DumpType.MemoryBufferSBE" "com.ibm.Dump.Create.CreateParameters.ErrorLogId" t 0xDEADBEEF "com.ibm.Dump.Create.CreateParameters.FailingUnitId" t 34
MESSAGE "o" {
        OBJECT_PATH "/xyz/openbmc_project/dump/sbe/entry/40000001";
};