### PR TITLE
dreport: Add audit.log Data to Dump

### DIFF
--- a/tools/dreport.d/plugins.d/auditlog
+++ b/tools/dreport.d/plugins.d/auditlog
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+#
+# config: 2 40
+# @brief: Save the audit log
+#
+
+# shellcheck disable=SC1091
+. "$DREPORT_INCLUDE"/functions
+
+# Multiple audit.log files can exist in the $log_path
+# directory. Copy all that exist to the dump.
+# The default configuration will limit to 5 files of
+# 2MB at most each. But if the configuration is altered we
+# want to copy all of the files which exist.
+desc="Audit Log"
+log_path="/var/log/audit/"
+
+if [ -e "$log_path" ]; then
+    add_copy_file "$log_path" "$desc"
+fi


### PR DESCRIPTION
Rebase 9ef050e Merge pull request #100 from jeaaustx/1050-auditLog

Add all /var/log/audit/audit.log files to BMC dumps. This file contains a log of the events that occurred and who initiated them.

Tested:
Verified audit.log files included in BMC dump.

Commits included:
```
a9c67a0 Audit Log: Allow auditlog plugin to be processed by shellcheck
d7c3038 Audit Log: Correct formatting errors in auditlog plugin
8f33a04 Audit Log: Corrected shellcheck errors in auditlog plugin
5689f30 Audit Log: Correct location for gathering audit log files. (#98)
5be61bf dreport: Add audit.log Data to Dump (#66)
```