### PR TITLE
Empty strings issue for start and end time of dump header corrected

### DIFF
--- a/tools/dreport.d/ibm.d/gendumpinfo
+++ b/tools/dreport.d/ibm.d/gendumpinfo
@@ -36,18 +36,18 @@ function dump_time_details() {
             $DUMP_PROP CompletedTime | awk '{print $2}')
     fi
 
-    if [ $? -ne 0 ]; then
-        echo "Could not fetch start time for $dump_id"
+    if [ $? -ne 0 ] || [ -z "$START_TIME" ] || [ "$START_TIME" -eq 0 ]; then
+        echo "Could not fetch start time for $dump_id. Setting manually"
         START_TIME=$(date +%s)
     fi
 
     start=$(date -d @$START_TIME +'%Y-%m-%d %H:%M:%S')
-    if [ $END_TIME -eq 0 ]; then
+    if [ -z "$END_TIME" ] || [ "$END_TIME" -eq 0 ]; then
+        echo "Could not fetch end time for $dump_id. Setting manually"
         END_TIME=$(date +"%s")
-        end=$(date -d @$END_TIME +'%Y-%m-%d %H:%M:%S')
-    else
-        end=$(date -d @$END_TIME +'%Y-%m-%d %H:%M:%S')
     fi
+    end=$(date -d @$END_TIME +'%Y-%m-%d %H:%M:%S')
+
     printf "dump-start-time: %s\n" "$start" >> $YAML_FILE
     printf "dump-end-time: %s\n" "$end" >> $YAML_FILE
 }


### PR DESCRIPTION
Problem: Sometimes start and end time strings of the dumpheader can not be fetched/retrieved from the busctl commands and that leads to failure in makedumptool parsing due to invalid dump header.

Solution: Now if the start and end time strings are coming blank for any reason we are setting them manually with the current date time to avoid wrong dump header.

Test Results:

Before:

phosphor-dump-manager[6158]: date: invalid date '@'
phosphor-dump-manager[6141]: /usr/share/dreport.d/include.d/gendumpinfo:
line 45: [: -eq: unary operator expected
phosphor-dump-manager[6159]: date: invalid date '@'

dumpfile.stats.actualTime = (yamlData['dump-end-time']
- yamlData['dump-start-time']).total_seconds() TypeError: unsupported operand type(s) for -: 'NoneType' and 'NoneType'

After:

phosphor-dump-manager[25497]: Could not fetch start time for 20000007
phosphor-dump-manager[25497]: End time populated as: 2024-03-19 15:02:32

>>>> Writing output
>>>> Final Results
All output collected in: /tmp
Dump File:
/tmp/SYSDUMP.139B0B0.20000007.20240319145934-MDC.dump (153.93 MB) Stats File:
/tmp/SYSDUMP.139B0B0.20000007.20240319145934-MDC.stats.bz2 (220.18 KB) Log File:
/tmp/SYSDUMP.139B0B0.20000007.20240319145934-MDC.log (11.05 MB) Console File:
/tmp/SYSDUMP.139B0B0.20000007.20240319145934-MDC.console (2.87 KB) HBMem File:
/tmp/SYSDUMP.139B0B0.20000007.20240319145934-MDC.hbmem (64.00 MB)

Upstream Gerrit: https://gerrit.openbmc.org/c/openbmc/phosphor-debug-collector/+/70119