### PR TITLE
Adding backup and min FW info in BMC dumps

### DIFF
--- a/tools/dreport.d/include.d/functions
+++ b/tools/dreport.d/include.d/functions
@@ -173,3 +173,71 @@ function fetch_serial_number() {
     fi
 }
 
+#Function to get the backup firmware details
+function add_backup_driver_details() {
+    OS_RELEASE_FILE="$name_dir/$1" ##Get the os-release file
+
+    if [ ! -f "$OS_RELEASE_FILE" ]; then
+        log_error "No os-release file in $name_dir"
+        return "$SUCCESS"
+    fi
+
+    dbus_object="xyz.openbmc_project.Software.BMC.Updater"
+    dbus_tree_command="busctl tree"
+    dbus_property_command="busctl get-property"
+    dbus_object_priority_method="xyz.openbmc_project.Software.RedundancyPriority"
+    dbus_object_priority="Priority"
+    dbus_object_version_method="xyz.openbmc_project.Software.Version"
+    dbus_object_version="Version"
+
+    ##Declare an array to store the results of dbus command
+    declare -a read_array=()
+
+    IFS=$'\n' read -r -d '' -a read_array < <( eval "$dbus_tree_command" "$dbus_object" && printf '\0' )
+
+    array_length=${#read_array[@]}
+
+    firmware1=""
+    firmware2=""
+
+    ##If there is only on FW image on the BMC return then and there
+    if [ "$array_length" -lt 5 ]; then
+        log_warning "No backup firmware on the BMC system as of now"
+        return "$SUCCESS"
+    else
+        firmware1=$(echo "${read_array[3]}" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
+        firmware2=$(echo "${read_array[4]}" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
+    fi
+
+    if [ -n "$firmware1" ]; then
+        firmware1=${firmware1:3}
+    fi
+
+    if [ -n "$firmware2" ]; then
+        firmware2=${firmware2:3}
+    fi
+
+    backup_firmware=""
+    dbus_command="$dbus_property_command $dbus_object $firmware1 $dbus_object_priority_method $dbus_object_priority"
+    ##Get the priority of the image. The one with the highest prirority amongst the two is the backup one
+    firmware1_priority=$(eval "$dbus_command" | grep -w "1" | cut -d' ' -f 2)
+    if [ -n  "$firmware1_priority" ]; then
+        dbus_command="$dbus_property_command $dbus_object $firmware1 $dbus_object_version_method $dbus_object_version"
+        backup_firmware=$(eval "$dbus_command" | cut -d' ' -f 2-)
+    else
+        dbus_command="$dbus_property_command $dbus_object $firmware2 $dbus_object_priority_method $dbus_object_priority"
+        firmware2_priority=$(eval "$dbus_command" | grep -w "1" | cut -d' ' -f 2)
+        if [ -n "$firmware2_priority" ]; then
+            dbus_command="$dbus_property_command $dbus_object $firmware2 $dbus_object_version_method $dbus_object_version"
+            backup_firmware=$(eval "$dbus_command" | cut -d' ' -f 2-)
+        fi
+    fi
+
+    if [ -n "$backup_firmware" ]; then
+        log_info "Backup firmware on BMC: $backup_firmware"
+        printf "\nBACKUP_FW=%s\n" "$backup_firmware" >> "$OS_RELEASE_FILE"
+    else
+        log_warning "BMC has no backup firmware at present"
+    fi
+}
+

--- a/tools/dreport.d/plugins.d/osrelease
+++ b/tools/dreport.d/plugins.d/osrelease
@@ -10,3 +10,6 @@ desc="OS release info"
 file_name="/etc/os-release"
 
 add_copy_sym_link_file "$file_name"  "$desc"
+
+file_name="os-release"
+add_backup_driver_details "$file_name"


### PR DESCRIPTION
Support now needs the non booting FW info along with active/booting FW in the os-release file of all the BMC dumps. They also asked for min FW level in the same file for all the BMC dumps.

This commit includes the changes to add the redundant or backup FW version name (if present) along with the active or booting FW in the os-release files for all the BMC dumps.

Test Results (confirmed by the PE team)

root@rain135bmc:/tmp/src/dumps# cat BMCDUMP.13BE960.0000053.20240510180023/os-release ID=openbmc-openpower
NAME="IBM eBMC (OpenBMC for IBM Enterprise Systems)" VERSION="fw1060.00-3.13"
VERSION_ID=fw1060.00-3.13-423-gcf5848428d-dirty
VERSION_CODENAME="nanbield"
PRETTY_NAME="IBM eBMC (OpenBMC for IBM Enterprise Systems) fw1060.00-3.13" CPE_NAME="cpe:/o:openembedded:openbmc-openpower:fw1060.00-3.13-423-gcf5848428d-dirty" BUILD_ID="20231117"
OPENBMC_TARGET_MACHINE="p10bmc"
EXTENDED_VERSION="fw1060.00-3.13-423-gcf5848428d-dirty"

BACKUP_FW="fw1060.00-16-1060.2420.20240508a (NL1060_042)"

![image (2)](https://github.com/ibm-openbmc/phosphor-debug-collector/assets/112170550/9e9f8b08-2fa5-4e1b-9f43-0083f969037b)
