### PR TITLE
dreport: Adding redundant FW info in BMC dumps

### DIFF
--- a/tools/dreport.d/plugins.d/redundantosrelease
+++ b/tools/dreport.d/plugins.d/redundantosrelease
@@ -1,0 +1,72 @@
+#!/bin/bash
+#
+# config: 2 50
+# @brief: Collect redundant OS information.
+
+# shellcheck disable=SC1091
+. "$DREPORT_INCLUDE/functions"
+
+desc="Redundant firmware info"
+file_name="redundant-os-release"
+
+# Declare necessary dbus interfaces
+dbus_object="xyz.openbmc_project.Software.BMC.Updater"
+dbus_tree_command="busctl tree"
+dbus_property_command="busctl get-property"
+dbus_object_priority_method="xyz.openbmc_project.Software.RedundancyPriority"
+dbus_object_priority="Priority"
+dbus_object_version_method="xyz.openbmc_project.Software.Version"
+dbus_object_version="Version"
+
+# Declare an array to store the results of dbus command
+read_array=()
+
+IFS=$'\n' read -r -d '' -a read_array < <( eval "$dbus_tree_command" "$dbus_object" && printf '\0' )
+
+array_length=${#read_array[@]}
+
+# If there is only one FW image on the BMC, return then and there
+if [ "$array_length" -lt 5 ]; then
+    return "$SUCCESS"
+fi
+
+firmware1=$(echo "${read_array[3]}" | xargs)
+firmware2=$(echo "${read_array[4]}" | xargs)
+
+if [ -n "$firmware1" ]; then
+    firmware1=${firmware1:3}
+fi
+
+if [ -n "$firmware2" ]; then
+    firmware2=${firmware2:3}
+fi
+
+redundant_firmware=""
+dbus_command="$dbus_property_command $dbus_object $firmware1 $dbus_object_priority_method \
+    $dbus_object_priority"
+
+# Get the priority of the image.
+# The one with the highest prirority amongst the two is the backup one
+firmware1_priority=$(eval "$dbus_command" | grep -w "1" | cut -d' ' -f 2)
+
+if [ -n  "$firmware1_priority" ]; then
+    dbus_command="$dbus_property_command $dbus_object $firmware1 $dbus_object_version_method \
+        $dbus_object_version"
+    redundant_firmware=$(eval "$dbus_command" | cut -d' ' -f 2-)
+else
+    dbus_command="$dbus_property_command $dbus_object $firmware2 $dbus_object_priority_method \
+        $dbus_object_priority"
+    firmware2_priority=$(eval "$dbus_command" | grep -w "1" | cut -d' ' -f 2)
+    if [ -n "$firmware2_priority" ]; then
+        dbus_command="$dbus_property_command $dbus_object $firmware2 $dbus_object_version_method \
+            $dbus_object_version"
+        redundant_firmware=$(eval "$dbus_command" | cut -d' ' -f 2-)
+    fi
+fi
+
+if [ -n "$redundant_firmware" ]; then
+    command="printf \"\nREDUNDANT_FW=%s\n\" \"\$redundant_firmware\""
+    add_cmd_output "$command" "$file_name" "$desc"
+else
+    log_warnig "No redundant FW available"
+fi


### PR DESCRIPTION
To support additional information, the non booting FW info is added in a separate file along with active/booting FW in the os-release file for all the BMC dumps.

This commit includes the changes to add the redundant or backup FW version name (if present), in a separate file named redundant-os-release file for all the BMC dumps.

Test Results:

cat BMCDUMP.13BE960.0000053.20240510180023/redundant-os-release

REDUNDANT_FW="fw1060.00-16-1060.2420.20240508a (NL1060_042)"