### PR TITLE
Support configurable dump filename

### DIFF
--- a/dump-extensions/openpower-dumps/dump_manager_openpower.cpp
+++ b/dump-extensions/openpower-dumps/dump_manager_openpower.cpp
@@ -87,7 +87,7 @@ void Manager::updateEntry(const std::filesystem::path& fullPath)
 
     uint32_t dumpId = std::stoi(dumpIdStr, 0, 16);
 
-    uint64_t timestamp = util::timeToEpoch(timestampStr);
+    uint64_t timestamp = phosphor::dump::timeToEpoch(timestampStr);
 
     uint64_t fileSize = std::filesystem::file_size(fullPath);
 

--- a/dump-extensions/openpower-dumps/op_dump_util.cpp
+++ b/dump-extensions/openpower-dumps/op_dump_util.cpp
@@ -195,26 +195,4 @@ openpower::dump::DumpParameters
             fid,      originatorId, originatorType};
 }
 
-uint64_t timeToEpoch(std::string timeStr)
-{
-    using namespace std::chrono;
-
-    std::tm t{};
-    std::istringstream ss(timeStr);
-    ss >> std::get_time(&t, "%Y%m%d%H%M%S");
-    if (ss.fail())
-    {
-        lg2::error("Invalid human readable time value {TIMESTRING}",
-                   "TIMESTRING", timeStr);
-        return std::chrono::duration_cast<std::chrono::microseconds>(
-                   std::chrono::system_clock::now().time_since_epoch())
-            .count();
-    }
-
-    auto sysTimeStamp = system_clock::from_time_t(std::mktime(&t));
-
-    // Return epoch time in microseconds
-    return duration_cast<microseconds>(sysTimeStamp.time_since_epoch()).count();
-}
-
 } // namespace openpower::dump::util

--- a/dump-extensions/openpower-dumps/op_dump_util.hpp
+++ b/dump-extensions/openpower-dumps/op_dump_util.hpp
@@ -108,6 +108,6 @@ inline void throwInvalidArgument(const std::string& argumentName,
     elog<InvalidArgument>(Argument::ARGUMENT_NAME(argumentName.c_str()),
                           Argument::ARGUMENT_VALUE(errorDetail.c_str()));
 }
-uint64_t timeToEpoch(std::string timeStr);
+
 } // namespace util
 } // namespace openpower::dump

--- a/dump_utils.hpp
+++ b/dump_utils.hpp
@@ -377,5 +377,38 @@ inline DumpTypes getErrorDumpType(phosphor::dump::DumpCreateParams& params)
     throw std::invalid_argument{"Dump type not found"};
 }
 
+/**
+ * @brief Converts human-readable timestamp to epoch
+ *
+ * This function takes a human-readable timestamp in the format "%Y%m%d%H%M%S"
+ * and converts it to a UNIX timestamp.
+ *
+ * @param timeStr - A human-readable timestamp in the format "%Y%m%d%H%M%S".
+ *
+ * @return A uint64_t value representing the equivalent UNIX timestamp. If
+ *         input string is malformatted current time will be returned.
+ */
+inline uint64_t timeToEpoch(std::string timeStr)
+{
+    using namespace std::chrono;
+
+    std::tm t{};
+    std::istringstream ss(timeStr);
+    ss >> std::get_time(&t, "%Y%m%d%H%M%S");
+    if (ss.fail())
+    {
+        lg2::error("Invalid human readable time value {TIMESTRING}",
+                   "TIMESTRING", timeStr);
+        return std::chrono::duration_cast<std::chrono::microseconds>(
+                   std::chrono::system_clock::now().time_since_epoch())
+            .count();
+    }
+
+    auto sysTimeStamp = system_clock::from_time_t(std::mktime(&t));
+
+    // Return epoch time in microseconds
+    return duration_cast<microseconds>(sysTimeStamp.time_since_epoch()).count();
+}
+
 } // namespace dump
 } // namespace phosphor

--- a/meson.build
+++ b/meson.build
@@ -115,6 +115,18 @@ conf_data.set_quoted('FAULTLOG_DUMP_PATH', get_option('FAULTLOG_DUMP_PATH'),
 conf_data.set('BMC_DUMP_ROTATE_CONFIG', get_option('dump_rotate_config').allowed(),
                description : 'Turn on rotate config for bmc dump'
              )
+conf_data.set_quoted('BMC_DUMP_FILENAME_REGEX', get_option('BMC_DUMP_FILENAME_REGEX'),
+                      description: 'BMC Dump filename format'
+            )
+conf_data.set('FILENAME_DUMP_ID_POS', get_option('FILENAME_DUMP_ID_POS'),
+               description : 'Position of dump id in the dump filename'
+             )
+conf_data.set('FILENAME_EPOCHTIME_POS', get_option('FILENAME_EPOCHTIME_POS'),
+               description : 'Position of timestamp in the dump filename'
+             )
+conf_data.set('TIMESTAMP_FORMAT', get_option('TIMESTAMP_FORMAT'),
+               description : 'Timestamp format in filename: 0-epoch 1-human readable'
+             )
 
 configure_file(configuration : conf_data,
                output : 'config.h'

--- a/meson.options
+++ b/meson.options
@@ -56,6 +56,21 @@ option('BMC_DUMP_TOTAL_SIZE', type : 'integer',
         description : 'Total size of the dump in kilo bytes'
       )
 
+option('BMC_DUMP_FILENAME_REGEX', type: 'string',
+        value: 'obmcdump_([0-9]+)_([0-9]+).([a-zA-Z0-9]+)',
+        description : 'BMC dump file format'
+      )
+
+option('FILENAME_DUMP_ID_POS', type : 'integer',
+        value : 1,
+        description : 'Position of dump id in dump filename'
+      )
+
+option('FILENAME_EPOCHTIME_POS', type : 'integer',
+        value : 2,
+        description : 'Position of timestamp in dump filename'
+      )
+
 option('ELOG_ID_PERSIST_PATH', type : 'string',
         value : '/var/lib/phosphor-debug-collector/elogid',
         description : 'Path of file for storing elog id\'s, which have associated dumps'
@@ -83,6 +98,11 @@ option('openpower-dumps-extension', type: 'feature',
 option('dump_rotate_config', type: 'feature',
         value : 'disabled',
         description : 'Enable rotate config for bmc dump'
+      )
+
+option('TIMESTAMP_FORMAT', type : 'integer',
+        value : 0,
+        description : 'Timestamp format in filename: 0-epoch 1-human readable'
       )
 
 # Fault log options


### PR DESCRIPTION
This commit adds support for customizable BMC dump filenames. IBM systems, for example, require a specific dump name format. It is documented within IBM that all subsystems involved in creating dumps need to follow this specific format. To meet this requirement and accommodate similar ones for other platforms, this commit introduces new meson options. These options allow for the specification of a custom filename format using a regular expression, and for the positions of the dump ID and timestamp within that format. This provides greater flexibility and ensures the dump naming process can be tailored to the platform's requirements.

An important note is that the dreport tool, which packages the dump, should also adapt to the same customizable filename format. Any discrepancy in the dump filename format will lead to those dumps being discarded by the dump manager as it will not be able to identify and process these dumps correctly.

Tests:

Tested with different formats for filename

Change-Id: I17ee17f0d2557479b60751114ff018391c3962e2