### PR TITLE
Updates to phosphor-dump-manager

### DIFF
--- a/bmc_dump_entry.hpp
+++ b/bmc_dump_entry.hpp
@@ -97,6 +97,9 @@ class Entry : virtual public phosphor::dump::Entry, virtual public EntryIfaces
         // TODO: serialization of this property will be handled with
         // #ibm-openbmc/2597
         completedTime(timeStamp);
+        const std::filesystem::path serializedFilePath =
+            filePath.parent_path() / ".preserve" / "serialized_entry.bin";
+        serialize(serializedFilePath);
     }
 };
 

--- a/dump-extensions/openpower-dumps/dump_entry_factory.cpp
+++ b/dump-extensions/openpower-dumps/dump_entry_factory.cpp
@@ -209,6 +209,7 @@ std::unique_ptr<phosphor::dump::Entry>
             return createHostbootDumpEntry(id, objPath, timeStamp, dumpParams);
         case OpDumpTypes::Hardware:
             return createHardwareDumpEntry(id, objPath, timeStamp, dumpParams);
+        case OpDumpTypes::MemoryBufferSBE:
         case OpDumpTypes::SBE:
             return createSBEDumpEntry(id, objPath, timeStamp, dumpParams);
         default:

--- a/dump-extensions/openpower-dumps/dump_entry_factory.cpp
+++ b/dump-extensions/openpower-dumps/dump_entry_factory.cpp
@@ -326,4 +326,31 @@ std::optional<std::unique_ptr<phosphor::dump::Entry>> DumpEntryFactory::notify(
     }
 }
 
+std::unique_ptr<phosphor::dump::Entry>
+    DumpEntryFactory::createEntryWithDefaults(
+        uint32_t id, const std::filesystem::path& objPath)
+{
+    auto type = getDumpTypeFromId(id);
+
+    switch (type)
+    {
+        case OpDumpTypes::System:
+            return std::make_unique<system::Entry>(bus, objPath.string(), id,
+                                                   mgr);
+        case OpDumpTypes::Resource:
+            return std::make_unique<resource::Entry>(bus, objPath.string(), id,
+                                                     mgr);
+        case OpDumpTypes::Hostboot:
+            return std::make_unique<hostboot::Entry>(bus, objPath.string(), id,
+                                                     mgr);
+        case OpDumpTypes::Hardware:
+            return std::make_unique<hardware::Entry>(bus, objPath.string(), id,
+                                                     mgr);
+        case OpDumpTypes::SBE:
+            return std::make_unique<sbe::Entry>(bus, objPath.string(), id, mgr);
+        default:
+            throw std::invalid_argument("Unsupported dump type");
+    }
+}
+
 } // namespace openpower::dump

--- a/dump-extensions/openpower-dumps/dump_entry_factory.cpp
+++ b/dump-extensions/openpower-dumps/dump_entry_factory.cpp
@@ -15,7 +15,6 @@ namespace openpower::dump
 
 using namespace phosphor::logging;
 using namespace sdbusplus::xyz::openbmc_project::Common::Error;
-constexpr uint32_t INVALID_SOURCE_ID = 0xFFFFFFFF;
 
 std::unique_ptr<phosphor::dump::Entry> DumpEntryFactory::createSystemDumpEntry(
     uint32_t id, std::filesystem::path& objPath, uint64_t timeStamp,

--- a/dump-extensions/openpower-dumps/dump_entry_factory.hpp
+++ b/dump-extensions/openpower-dumps/dump_entry_factory.hpp
@@ -70,6 +70,10 @@ class DumpEntryFactory
         const std::map<uint32_t, std::unique_ptr<phosphor::dump::Entry>>&
             entries);
 
+    std::unique_ptr<phosphor::dump::Entry>
+        createEntryWithDefaults(uint32_t id,
+                                const std::filesystem::path& objPath);
+
   private:
     /**
      * @brief Creates a system dump entry.

--- a/dump-extensions/openpower-dumps/dump_entry_factory.hpp
+++ b/dump-extensions/openpower-dumps/dump_entry_factory.hpp
@@ -190,7 +190,7 @@ class DumpEntryFactory
             case 0x30000000:
                 return OpDumpTypes::SBE;
             case 0x40000000:
-		return OpDumpTypes::MemoryBufferSBE; 
+                return OpDumpTypes::MemoryBufferSBE;
             case 0xA0000000:
                 return OpDumpTypes::System;
             case 0xB0000000:

--- a/dump-extensions/openpower-dumps/dump_entry_factory.hpp
+++ b/dump-extensions/openpower-dumps/dump_entry_factory.hpp
@@ -151,6 +151,8 @@ class DumpEntryFactory
                 return 0x20000000;
             case OpDumpTypes::SBE:
                 return 0x30000000;
+            case OpDumpTypes::MemoryBufferSBE:
+                return 0x30000000;
             case OpDumpTypes::System:
                 return 0xA0000000;
             case OpDumpTypes::Resource:
@@ -183,6 +185,8 @@ class DumpEntryFactory
                 return OpDumpTypes::Hostboot;
             case 0x30000000:
                 return OpDumpTypes::SBE;
+            case 0x40000000:
+		return OpDumpTypes::MemoryBufferSBE; 
             case 0xA0000000:
                 return OpDumpTypes::System;
             case 0xB0000000:

--- a/dump-extensions/openpower-dumps/dump_manager_openpower.hpp
+++ b/dump-extensions/openpower-dumps/dump_manager_openpower.hpp
@@ -94,11 +94,7 @@ class Manager :
         dumpDir(filePath)
     {}
 
-    void restore() override
-    {
-        // TODO #2597  Implement the restore to restore the dump entries
-        // after the service restart.
-    }
+    void restore() override;
 
     /** @brief Notify the system dump manager about creation of a new dump.
      *  @param[in] dumpId - Id from the source of the dump.

--- a/dump-extensions/openpower-dumps/openpower_dump_entry.hpp
+++ b/dump-extensions/openpower-dumps/openpower_dump_entry.hpp
@@ -57,6 +57,19 @@ class Entry : public virtual phosphor::dump::Entry
                               parent)
     {}
 
+    /** @brief Constructor for creating a dump entry with default values
+     *  @param[in] bus - Bus to attach to.
+     *  @param[in] objPath - Object path to attach to.
+     *  @param[in] dumpId - Unique identifier for the dump.
+     *  @param[in] parent - Reference to the managing dump manager.
+     */
+    Entry(sdbusplus::bus_t& bus, const std::string& objPath, uint32_t dumpId,
+          phosphor::dump::Manager& parent) :
+        phosphor::dump::Entry(bus, objPath.c_str(), dumpId, 0, 0, "",
+                              phosphor::dump::OperationStatus::InProgress, "",
+                              originatorTypes::Internal, parent)
+    {}
+
     /** @brief Delete the dump and D-Bus object
      */
     void delete_() override;
@@ -84,6 +97,10 @@ class Entry : public virtual phosphor::dump::Entry
         // TODO: serialization of this property will be handled with
         // #ibm-openbmc/2597
         completedTime(timeStamp);
+
+        const std::filesystem::path serializedFilePath =
+            filePath.parent_path() / ".preserve" / "serialized_entry.bin";
+        serialize(serializedFilePath);
     }
 };
 
@@ -140,6 +157,22 @@ class Entry : public virtual openpower::dump::Entry, public virtual HostbootIntf
         errorLogId(eid);
         this->openpower::dump::hostboot::HostbootIntf::emit_object_added();
     }
+
+    /** @brief Constructor for creating a Hostboot dump entry with default
+     * values
+     *  @param[in] bus - Bus to attach to.
+     *  @param[in] objPath - Object path to attach to.
+     *  @param[in] dumpId - Unique identifier for the dump.
+     *  @param[in] parent - Reference to the managing dump manager.
+     */
+    Entry(sdbusplus::bus_t& bus, const std::string& objPath, uint32_t dumpId,
+          phosphor::dump::Manager& parent) :
+        phosphor::dump::Entry(bus, objPath.c_str(), dumpId, 0, 0, "",
+                              phosphor::dump::OperationStatus::InProgress, "",
+                              originatorTypes::Internal, parent),
+        openpower::dump::Entry(bus, objPath.c_str(), dumpId, parent),
+        HostbootIntf(bus, objPath.c_str(), HostbootIntf::action::defer_emit)
+    {}
 };
 
 } // namespace hostboot
@@ -199,6 +232,22 @@ class Entry : public virtual openpower::dump::Entry, public virtual HardwareIntf
         failingUnitId(failingUnit);
         this->openpower::dump::hardware::HardwareIntf::emit_object_added();
     }
+
+    /** @brief Constructor for creating a Hardware dump entry with default
+     * values
+     *  @param[in] bus - Bus to attach to.
+     *  @param[in] objPath - Object path to attach to.
+     *  @param[in] dumpId - Unique identifier for the dump.
+     *  @param[in] parent - Reference to the managing dump manager.
+     */
+    Entry(sdbusplus::bus_t& bus, const std::string& objPath, uint32_t dumpId,
+          phosphor::dump::Manager& parent) :
+        phosphor::dump::Entry(bus, objPath.c_str(), dumpId, 0, 0, "",
+                              phosphor::dump::OperationStatus::InProgress, "",
+                              originatorTypes::Internal, parent),
+        openpower::dump::Entry(bus, objPath.c_str(), dumpId, parent),
+        HardwareIntf(bus, objPath.c_str(), HardwareIntf::action::defer_emit)
+    {}
 };
 } // namespace hardware
 
@@ -257,6 +306,21 @@ class Entry : public virtual openpower::dump::Entry, public virtual SBEIntf
         failingUnitId(failingUnit);
         this->openpower::dump::sbe::SBEIntf::emit_object_added();
     }
+
+    /** @brief Constructor for creating an SBE dump entry with default values
+     *  @param[in] bus - Bus to attach to.
+     *  @param[in] objPath - Object path to attach to.
+     *  @param[in] dumpId - Unique identifier for the dump.
+     *  @param[in] parent - Reference to the managing dump manager.
+     */
+    Entry(sdbusplus::bus_t& bus, const std::string& objPath, uint32_t dumpId,
+          phosphor::dump::Manager& parent) :
+        phosphor::dump::Entry(bus, objPath.c_str(), dumpId, 0, 0, "",
+                              phosphor::dump::OperationStatus::InProgress, "",
+                              originatorTypes::Internal, parent),
+        openpower::dump::Entry(bus, objPath.c_str(), dumpId, parent),
+        SBEIntf(bus, objPath.c_str(), SBEIntf::action::defer_emit)
+    {}
 };
 } // namespace sbe
 

--- a/dump-extensions/openpower-dumps/resource_dump_entry.hpp
+++ b/dump-extensions/openpower-dumps/resource_dump_entry.hpp
@@ -108,6 +108,22 @@ class Entry : virtual public phosphor::dump::Entry, virtual public EntryIfaces
         // Emit deferred signal.
         this->openpower::dump::resource::EntryIfaces::emit_object_added();
     };
+
+    /** @brief Constructor for creating a Resource dump entry with default
+     * values
+     *  @param[in] bus - Bus to attach to.
+     *  @param[in] objPath - Object path to attach to.
+     *  @param[in] dumpId - Unique identifier for the dump.
+     *  @param[in] parent - Reference to the managing dump manager.
+     */
+    Entry(sdbusplus::bus_t& bus, const std::string& objPath, uint32_t dumpId,
+          phosphor::dump::Manager& parent) :
+        phosphor::dump::Entry(bus, objPath.c_str(), dumpId, 0, 0, "",
+                              phosphor::dump::OperationStatus::InProgress, "",
+                              originatorTypes::Internal, parent),
+        EntryIfaces(bus, objPath.c_str(), EntryIfaces::action::defer_emit)
+    {}
+
     /** @brief Method to initiate the offload of dump
      *  @param[in] uri - URI to offload dump.
      */

--- a/dump-extensions/openpower-dumps/resource_dump_entry.hpp
+++ b/dump-extensions/openpower-dumps/resource_dump_entry.hpp
@@ -2,6 +2,7 @@
 
 #include "com/ibm/Dump/Entry/Resource/server.hpp"
 #include "dump_entry.hpp"
+#include "op_dump_consts.hpp"
 
 #include <sdbusplus/bus.hpp>
 #include <sdbusplus/server/object.hpp>
@@ -107,6 +108,7 @@ class Entry : virtual public phosphor::dump::Entry, virtual public EntryIfaces
 
         // Emit deferred signal.
         this->openpower::dump::resource::EntryIfaces::emit_object_added();
+        serializeEntry();
     };
 
     /** @brief Constructor for creating a Resource dump entry with default
@@ -146,12 +148,35 @@ class Entry : virtual public phosphor::dump::Entry, virtual public EntryIfaces
         status(OperationStatus::Completed);
         completedTime(timeStamp);
         dumpRequestStatus(HostResponse::Success);
+
+        serializeEntry();
     }
 
     /**
      * @brief Delete resource dump in host memory and the entry dbus object
      */
     void delete_() override;
+
+    /** @brief Serialize the resource dump entry
+     *  @param[in] filePath - Path to the file where the entry will be
+     * serialized
+     */
+    void serialize(const std::filesystem::path& filePath) override;
+
+    /** @brief Deserialize the resource dump entry
+     *  @param[in] filePath - Path to the file from where the entry will be
+     * deserialized
+     */
+    void deserialize(const std::filesystem::path& filePath) override;
+
+    inline void serializeEntry()
+    {
+        std::string idStr = std::format("{:08X}", getDumpId());
+        const std::filesystem::path serializedFilePath =
+            std::filesystem::path(openpower::dump::OP_DUMP_PATH) / idStr /
+            ".preserve" / "serialized_entry.bin";
+        serialize(serializedFilePath);
+    }
 };
 
 } // namespace resource

--- a/dump-extensions/openpower-dumps/system_dump_entry.cpp
+++ b/dump-extensions/openpower-dumps/system_dump_entry.cpp
@@ -68,6 +68,71 @@ void Entry::delete_()
     // Remove Dump entry D-bus object
     phosphor::dump::Entry::delete_();
 }
+
+void Entry::serialize(const std::filesystem::path& filePath)
+{
+    try
+    {
+        std::filesystem::path dir = filePath.parent_path();
+        if (!std::filesystem::exists(dir))
+        {
+            std::filesystem::create_directories(dir);
+        }
+
+        std::ofstream ofs(filePath, std::ios::binary);
+        if (!ofs.is_open())
+        {
+            lg2::error("Failed to open file for serialization: {PATH} ", "PATH",
+                       filePath);
+        }
+        cereal::BinaryOutputArchive archive(ofs);
+        archive(sourceDumpId(), size(), originatorId(), originatorType(),
+                completedTime(), elapsed(), startTime());
+    }
+    catch (const std::exception& e)
+    {
+        lg2::error("Serialization error: {PATH} {ERROR} ", "PATH", filePath,
+                   "ERROR", e);
+    }
+}
+
+void Entry::deserialize(const std::filesystem::path& filePath)
+{
+    try
+    {
+        std::ifstream ifs(filePath, std::ios::binary);
+        if (!ifs.is_open())
+        {
+            lg2::error("Failed to open file for deserialization: {PATH}",
+                       "PATH", filePath);
+        }
+
+        cereal::BinaryInputArchive archive(ifs);
+        uint32_t sourceId;
+        uint64_t dumpSize;
+        std::string originId;
+        originatorTypes originType;
+        uint64_t dumpCompletedTime;
+        uint64_t dumpElapsed;
+        uint64_t dumpStartTime;
+        archive(sourceId, dumpSize, originId, originType, dumpCompletedTime,
+                dumpElapsed, dumpStartTime);
+        sourceDumpId(sourceId);
+        size(dumpSize);
+        originatorId(originId);
+        originatorType(originType);
+        completedTime(dumpCompletedTime);
+        elapsed(dumpElapsed);
+        startTime(dumpStartTime);
+        status(OperationStatus::Completed);
+    }
+    catch (const std::exception& e)
+    {
+        lg2::error("Deserialization error: {PATH}, {ERROR}", "PATH", filePath,
+                   "ERROR", e);
+    }
+}
+
 } // namespace system
 } // namespace dump
 } // namespace openpower

--- a/dump-extensions/openpower-dumps/system_dump_entry.hpp
+++ b/dump-extensions/openpower-dumps/system_dump_entry.hpp
@@ -100,6 +100,20 @@ class Entry : virtual public phosphor::dump::Entry, virtual public EntryIfaces
         this->openpower::dump::system::EntryIfaces::emit_object_added();
     };
 
+    /** @brief Constructor for creating a System dump entry with default values
+     *  @param[in] bus - Bus to attach to.
+     *  @param[in] objPath - Object path to attach to.
+     *  @param[in] dumpId - Unique identifier for the dump.
+     *  @param[in] parent - Reference to the managing dump manager.
+     */
+    Entry(sdbusplus::bus_t& bus, const std::string& objPath, uint32_t dumpId,
+          phosphor::dump::Manager& parent) :
+        phosphor::dump::Entry(bus, objPath.c_str(), dumpId, 0, 0, "",
+                              phosphor::dump::OperationStatus::InProgress, "",
+                              originatorTypes::Internal, parent),
+        EntryIfaces(bus, objPath.c_str(), EntryIfaces::action::defer_emit)
+    {}
+
     /** @brief Method to initiate the offload of dump
      *  @param[in] uri - URI to offload dump.
      */

--- a/dump_entry.hpp
+++ b/dump_entry.hpp
@@ -6,12 +6,16 @@
 #include "xyz/openbmc_project/Object/Delete/server.hpp"
 #include "xyz/openbmc_project/Time/EpochTime/server.hpp"
 
+#include <cereal/archives/binary.hpp>
+#include <cereal/types/string.hpp>
+#include <phosphor-logging/lg2.hpp>
 #include <sdbusplus/bus.hpp>
 #include <sdbusplus/server/object.hpp>
 #include <sdeventplus/event.hpp>
 #include <sdeventplus/source/event.hpp>
 
 #include <filesystem>
+#include <fstream>
 
 namespace phosphor
 {
@@ -126,6 +130,22 @@ class Entry : public EntryIfaces
      *  the file string is empty
      */
     sdbusplus::message::unix_fd getFileHandle() override;
+
+    /**
+     * @brief Serialize the dump entry attributes to a file.
+     *
+     * @param[in] filePath - The path to the file where the entry will be
+     *                       serialized.
+     */
+    virtual void serialize(const std::filesystem::path& filePath);
+
+    /**
+     * @brief Deserialize the dump entry attributes from a file.
+     *
+     * @param[in] filePath - The path to the file from where the entry
+     *                       will be deserialized.
+     */
+    virtual void deserialize(const std::filesystem::path& filePath);
 
   protected:
     /** @brief This entry's parent */

--- a/dump_manager_bmc.cpp
+++ b/dump_manager_bmc.cpp
@@ -186,15 +186,15 @@ void Manager::createEntry(const std::filesystem::path& file)
 
     auto idString = match[FILENAME_DUMP_ID_POS];
     auto ts = match[FILENAME_EPOCHTIME_POS];
-    uint64_t timestamp = 1000 * 1000;
+    uint64_t timestamp = 0;
 
     if (TIMESTAMP_FORMAT == 1)
     {
-        timestamp *= timeToEpoch(ts);
+        timestamp = timeToEpoch(ts);
     }
     else
     {
-        timestamp *= stoull(ts);
+        timestamp = stoull(ts) * 1000 * 1000;
     }
 
     auto id = stoul(idString);

--- a/dump_manager_bmc.hpp
+++ b/dump_manager_bmc.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "dump_entry.hpp"
 #include "dump_manager.hpp"
 #include "dump_utils.hpp"
 #include "watch.hpp"
@@ -84,7 +85,7 @@ class Manager :
     /** @brief Create Dump entry d-bus object
      *  @param[in] fullPath - Full path of the Dump file name
      */
-    void createEntry(const std::filesystem::path& fullPath);
+    phosphor::dump::Entry* createEntry(const std::filesystem::path& fullPath);
 
     /** @brief Capture BMC Dump based on the Dump type.
      *  @param[in] type - Type of the dump to pass to dreport


### PR DESCRIPTION
71728: OpenPOWER: Memory Buffer SBE dump support | https://gerrit.openbmc.org/c/openbmc/phosphor-debug-collector/+/71728

71731: Add Serialization Support for Dump Entry Attributes | https://gerrit.openbmc.org/c/openbmc/phosphor-debug-collector/+/71731

71732: OpenPOWER: Add serialization support | https://gerrit.openbmc.org/c/openbmc/phosphor-debug-collector/+/71732

71733: OpenPOWER: Serialization support for dumps in host memory | https://gerrit.openbmc.org/c/openbmc/phosphor-debug-collector/+/71733
