### PR TITLE
gendumpheader: Generator ID info added

### DIFF
--- a/tools/dreport.d/dreport
+++ b/tools/dreport.d/dreport
@@ -221,6 +221,8 @@ function initialize()
        valid_size=$UNLIMITED
     fi
 
+    get_generator_id
+
     return $SUCCESS
 }
 

--- a/tools/dreport.d/ibm.d/gendumpheader
+++ b/tools/dreport.d/ibm.d/gendumpheader
@@ -32,6 +32,19 @@ function add_null () {
     printf '%*s' "$a" | tr ' ' "\0" >> "$FILE"
 }
 
+function add_generator_id() {
+    if [ -z "$GENERATOR_ID" ]; then
+        add_null 32
+        return
+    fi
+    printf '%s' "$GENERATOR_ID" >> "$FILE"
+    len=${#GENERATOR_ID}
+    nulltoadd=$(( SIZE_32 - len ))
+    if [ "$nulltoadd" -eq 0 ]; then
+        add_null "$nulltoadd"
+    fi
+}
+
 #Function to is to convert the EPOCHTIME collected
 #from dreport into hex values and write the same in
 #header.
@@ -321,7 +334,10 @@ function dump_header () {
     add_null 2 # SRC size
     add_null 320 # SRC dump
     getbmc_serial
-    add_null 68 # Dump requester details
+    add_null 4  #Dump requestor type
+    # Dump requester/generator id
+    add_generator_id
+    add_null 32 # Dump Req user ID
 }
 
 #Function to add Dump entry, consists of below entries

--- a/tools/dreport.d/include.d/dcommon
+++ b/tools/dreport.d/include.d/dcommon
@@ -23,6 +23,9 @@ declare -x serialNo="0000000"
 declare -x dDay=$(date -d @$EPOCHTIME +'%Y%m%d%H%M%S')
 declare -x FILE=""
 
+#Source dreport common functions
+. $DREPORT_INCLUDE/functions
+
 # @brief get serial number property from inventory
 function fetch_serial_number () {
     serialNo=$(busctl get-property $INVENTORY_MANAGER $INVENTORY_PATH \
@@ -84,3 +87,5 @@ function validate_arg () {
 }
 
 fetch_serial_number
+
+get_generator_id

--- a/tools/dreport.d/include.d/functions
+++ b/tools/dreport.d/include.d/functions
@@ -157,3 +157,60 @@ function log_summary()
         echo $($TIME_STAMP) "$*" >&1
     fi
 }
+
+#Dump generator params
+declare -x GENERATOR_ID=""
+
+#Function to get the Originator details
+#for Originator Type and Originator ID
+function get_generator_id() {
+    # A hash map for each possible dump types
+    # Add/Remove as per the requirement
+    local -A dump_name_map
+    dump_name_map["dumps"]="bmc"
+    dump_name_map["faultlogs"]="faultlog"
+    dump_name_map["hardwaredump"]="hardware"
+    dump_name_map["hostbootdump"]="hostboot"
+    dump_name_map["msbedump"]="msbe"
+    dump_name_map["sbedump"]="sbe"
+
+    dump_type_received=$(echo "$dump_dir" | cut -d'/' -f 5)
+    dump_entry_id=$(echo "$dump_dir" | cut -d'/' -f 6)
+
+    dump_type_mapped=""
+
+    for key in "${!dump_name_map[@]}"
+    do
+        if [ "$key" = "$dump_type_received" ]; then
+            dump_type_mapped="${dump_name_map[$key]}"
+            break
+        fi
+    done
+
+    # If the dump type received is not in the known list/map
+    # then return then and there to avoid the dbus call which
+    # would be definitely failed due to wrong object path string
+    # made by th line
+    # DBUS_DUMP_PATH="/xyz/openbmc_project/dump/$dump_type_mapped/entry/$dump_entry_id"
+    if [ -z "$dump_type_mapped" ]; then
+        return
+    fi
+
+    local DBUS_DUMP_MANAGER="xyz.openbmc_project.Dump.Manager"
+    local DBUS_DUMP_PATH="/xyz/openbmc_project/dump/$dump_type_mapped/entry/$dump_entry_id"
+    local DBUS_DUMP_ORIGINATROR_IFACE="xyz.openbmc_project.Common.GeneratedBy"
+    local DBUS_ORIGINATOR_ID_STRING="GeneratorId"
+
+    GENERATOR_ID=$(busctl get-property "$DBUS_DUMP_MANAGER" "$DBUS_DUMP_PATH" \
+        "$DBUS_DUMP_ORIGINATROR_IFACE" "$DBUS_ORIGINATOR_ID_STRING")
+
+    # The following line would extract the generator id
+    # from the received long string in response of the above dbus calls
+    # like <s "123456789">
+    # to only <123456789> for the generator ID
+
+    if [ -n "$GENERATOR_ID" ]; then
+        GENERATOR_ID=$(echo "$GENERATOR_ID" | \
+            cut -d' ' -f 2 | cut -d'"' -f 1)
+    fi
+}


### PR DESCRIPTION
There is a parameter available for each dump,
Generator ID. This change aims to include this
field into the dump header.

If for any reason the generator ID is unavailable then it is been replaced by their allocated null bytes.

Test Results:
Tested on generated BMC dumps and verified.