### PR TITLE
dreport: Min FW info added

### DIFF
--- a/tools/dreport.d/include.d/functions
+++ b/tools/dreport.d/include.d/functions
@@ -160,3 +160,77 @@ function log_summary()
         echo $($TIME_STAMP) "$*" >&1
     fi
 }
+
+# Redundant OS and Min FW Level
+declare -x REDUNDANT_FW_VERSION=""
+declare -x MIN_FW_VERSION_LEVEL=""
+
+# @brief Get Redundant OS and Min FW version
+function populate_redundant_os_n_min_fw_info()
+{
+    # Declare necessary dbus interfaces
+    dbus_object="xyz.openbmc_project.Software.BMC.Updater"
+    dbus_object_software="/xyz/openbmc_project/software/"
+    grep_command="grep $dbus_object_software"
+    dbus_tree_command="busctl --list --no-pager tree $dbus_object | $grep_command"
+    dbus_property_command="busctl get-property"
+    dbus_object_priority_method="xyz.openbmc_project.Software.RedundancyPriority"
+    dbus_object_priority="Priority"
+    dbus_object_version_method="xyz.openbmc_project.Software.Version"
+    dbus_object_version="Version"
+    dbus_object_min_version_method="xyz.openbmc_project.Software.MinimumVersion"
+    dbus_object_min_version="MinimumVersion"
+
+    # Declare an array to store the results of dbus command
+    read_array=()
+
+    IFS=$'\n' read -r -d '' -a read_array < <( eval "$dbus_tree_command" && printf '\0' )
+
+    array_length=${#read_array[@]}
+
+    # If there is only one FW image on the BMC,
+    # then there is no question of redundant FW
+    # but we can still try to get the min FW info from it
+    if [ "$array_length" -lt 2 ]; then
+        firmware=$(echo "${read_array[0]}" | xargs)
+
+        dbus_command="$dbus_property_command $dbus_object $firmware \
+            $dbus_object_min_version_method $dbus_object_min_version"
+
+        MIN_FW_VERSION_LEVEL=$(eval "$dbus_command" | cut -d' ' -f 2-)
+
+        return "$SUCCESS"
+    fi
+
+    firmware1=$(echo "${read_array[0]}" | xargs)
+    firmware2=$(echo "${read_array[1]}" | xargs)
+
+    # Get the priority of the first firmware image.
+    # The one with the highest prirority amongst the two is the backup one
+    # And the one with the lowest priority amongst the two is the active one
+    dbus_command="$dbus_property_command $dbus_object $firmware1 \
+        $dbus_object_priority_method $dbus_object_priority"
+
+    firmware1_priority=$(eval "$dbus_command" | cut -d' ' -f 2)
+
+    # If FW1 is the redundant one then get the redundant info from FW1
+    # and get the min FW version info from FW2 or vice-versa
+    firmware_primary=""
+    firmware_secondary=""
+
+    if [ 1 -eq  "$firmware1_priority" ]; then
+        firmware_primary="$firmware2"
+        firmware_secondary="$firmware1"
+    else
+        firmware_primary="$firmware1"
+        firmware_secondary="$firmware2"
+    fi
+
+    dbus_command="$dbus_property_command $dbus_object $firmware_secondary \
+        $dbus_object_version_method $dbus_object_version"
+    REDUNDANT_FW_VERSION=$(eval "$dbus_command" | cut -d' ' -f 2-)
+
+    dbus_command="$dbus_property_command $dbus_object $firmware_primary \
+        $dbus_object_min_version_method $dbus_object_min_version"
+    MIN_FW_VERSION_LEVEL=$(eval "$dbus_command" | cut -d' ' -f 2-)
+}

--- a/tools/dreport.d/plugins.d/minfwlevelinfo
+++ b/tools/dreport.d/plugins.d/minfwlevelinfo
@@ -1,0 +1,24 @@
+#!/bin/bash
+#
+# config: 2 50
+# @brief: Collect Min FW level version info
+
+# shellcheck disable=SC1091
+. "$DREPORT_INCLUDE/functions"
+
+desc="Minimum firmware level info"
+file_name="min-fw-level"
+
+# Check if already it has been populated via redundantosrelease plugin,
+# if not then populate
+if [ -z "$MIN_FW_VERSION_LEVEL" ]; then
+    populate_redundant_os_n_min_fw_info
+fi
+
+if [ -n "$MIN_FW_VERSION_LEVEL" ]; then
+    command="printf \"\nMIN_FW_LEVEL=%s\n\" \"\$MIN_FW_VERSION_LEVEL\""
+    add_cmd_output "$command" "$file_name" "$desc"
+else
+    log_warning "No min FW level info available"
+fi
+

--- a/tools/dreport.d/plugins.d/redundantosrelease
+++ b/tools/dreport.d/plugins.d/redundantosrelease
@@ -9,64 +9,16 @@
 desc="Redundant firmware info"
 file_name="redundant-os-release"
 
-# Declare necessary dbus interfaces
-dbus_object="xyz.openbmc_project.Software.BMC.Updater"
-dbus_tree_command="busctl tree"
-dbus_property_command="busctl get-property"
-dbus_object_priority_method="xyz.openbmc_project.Software.RedundancyPriority"
-dbus_object_priority="Priority"
-dbus_object_version_method="xyz.openbmc_project.Software.Version"
-dbus_object_version="Version"
-
-# Declare an array to store the results of dbus command
-read_array=()
-
-IFS=$'\n' read -r -d '' -a read_array < <( eval "$dbus_tree_command" "$dbus_object" && printf '\0' )
-
-array_length=${#read_array[@]}
-
-# If there is only one FW image on the BMC, return then and there
-if [ "$array_length" -lt 5 ]; then
-    return "$SUCCESS"
+# Check if already it has been populated via minfwlevelinfo plugin,
+# if not then populate
+if [ -z "$REDUNDANT_FW_VERSION" ]; then
+    populate_redundant_os_n_min_fw_info
 fi
 
-firmware1=$(echo "${read_array[3]}" | xargs)
-firmware2=$(echo "${read_array[4]}" | xargs)
-
-if [ -n "$firmware1" ]; then
-    firmware1=${firmware1:3}
-fi
-
-if [ -n "$firmware2" ]; then
-    firmware2=${firmware2:3}
-fi
-
-redundant_firmware=""
-dbus_command="$dbus_property_command $dbus_object $firmware1 $dbus_object_priority_method \
-    $dbus_object_priority"
-
-# Get the priority of the image.
-# The one with the highest prirority amongst the two is the backup one
-firmware1_priority=$(eval "$dbus_command" | grep -w "1" | cut -d' ' -f 2)
-
-if [ -n  "$firmware1_priority" ]; then
-    dbus_command="$dbus_property_command $dbus_object $firmware1 $dbus_object_version_method \
-        $dbus_object_version"
-    redundant_firmware=$(eval "$dbus_command" | cut -d' ' -f 2-)
-else
-    dbus_command="$dbus_property_command $dbus_object $firmware2 $dbus_object_priority_method \
-        $dbus_object_priority"
-    firmware2_priority=$(eval "$dbus_command" | grep -w "1" | cut -d' ' -f 2)
-    if [ -n "$firmware2_priority" ]; then
-        dbus_command="$dbus_property_command $dbus_object $firmware2 $dbus_object_version_method \
-            $dbus_object_version"
-        redundant_firmware=$(eval "$dbus_command" | cut -d' ' -f 2-)
-    fi
-fi
-
-if [ -n "$redundant_firmware" ]; then
-    command="printf \"\nREDUNDANT_FW=%s\n\" \"\$redundant_firmware\""
+if [ -n "$REDUNDANT_FW_VERSION" ]; then
+    command="printf \"\nREDUNDANT_FW_VERSION=%s\n\" \"\$nREDUNDANT_FW_VERSION\""
     add_cmd_output "$command" "$file_name" "$desc"
 else
-    log_warnig "No redundant FW available"
+    log_warning "No redundant FW available"
 fi
+


### PR DESCRIPTION
It has been requested that while generating BMC dumps it should include minimum F/W level supported info.

These changes aim to incorporate the above said request by creating one plugin, namely minfwlevelinfo, under dreport. If in case the info is not available then it logs a related warning in dreportlog file about it.

Also the redundantosrelease plugin file has been modified because both the plugins, redundantosrelease and minfwlevelinfo use same lines of code almost, and thus, putting that in the functions script we can make them available for both the plugins. And with little bit of pre checks in the related plugins we avoid unnecessary repetitive calls of the same code and dbus invokes.

Test Results:

Tested for both the plugins for both positive and negative cases and found the results as per the expectations