### PR TITLE
Skip .preserve file while creating a dbus entry

### DIFF
--- a/dump_manager_bmc.cpp
+++ b/dump_manager_bmc.cpp
@@ -294,7 +294,6 @@ void Manager::restore()
     for (const auto& p : std::filesystem::directory_iterator(dir))
     {
         auto idStr = p.path().filename().string();
-
         // Consider only directories with dump id as name.
         // Note: As per design one file per directory.
         if ((std::filesystem::is_directory(p.path())) &&
@@ -302,11 +301,15 @@ void Manager::restore()
         {
             lastEntryId = std::max(lastEntryId,
                                    static_cast<uint32_t>(std::stoul(idStr)));
-            auto fileIt = std::filesystem::directory_iterator(p.path());
             // Create dump entry d-bus object.
-            if (fileIt != std::filesystem::end(fileIt))
+            for (const auto& fileIt :
+                 std::filesystem::directory_iterator(p.path()))
             {
-                auto entry = createEntry(fileIt->path());
+                if (fileIt.path().filename() == ".preserve")
+                {
+                    continue;
+                }
+                auto entry = createEntry(fileIt.path());
 
                 if (entry != nullptr)
                 {


### PR DESCRIPTION
For each dump directory, we create a dbus entry if not present or update it if there is an existing entry. Now, we have .preserve file along with the Dump file in the directory. So, skipping .preserve file and creating an entry for the dump file if exists.

Test Results:

Before:
Sep 17 10:27:05 p10bmc systemd[1]: Starting Phosphor Dump Manager... Sep 17 10:27:05 p10bmc phosphor-dump-manager[6765]: Invalid Dump file name, FILENAME: /var/lib/phosphor-debug-collector/dumps/4/.preserve Sep 17 10:27:05 p10bmc phosphor-dump-manager[6765]: Invalid Dump file name, FILENAME: /var/lib/phosphor-debug-collector/dumps/1/.preserve Sep 17 10:27:05 p10bmc phosphor-dump-manager[6765]: dump_manager_ faultlog restore not implemented
Sep 17 10:27:05 p10bmc systemd[1]: Started Phosphor Dump Manager.

After:
Sep 17 12:06:30 p10bmc systemd[1]: Starting Phosphor Dump Manager... Sep 17 12:06:31 p10bmc phosphor-dump-manager[11105]: dump_manager_ faultlog restore not implemented
Sep 17 12:06:31 p10bmc systemd[1]: Started Phosphor Dump Manager.

Change-Id: I5fc2536095436ea5debb2c43aef13bbdcbea46e9