### PR TITLE
Add bmcweb host and session details to BMC dump

### DIFF
--- a/tools/dreport.d/plugins.d/bmcweb
+++ b/tools/dreport.d/plugins.d/bmcweb
@@ -1,0 +1,17 @@
+#!/bin/bash
+#
+# config: 123 20
+# @brief: Get bmcweb session details
+#
+
+. "$DREPORT_INCLUDE/functions"
+
+# collect data only if bmcweb is present
+if [ -e "/usr/bin/bmcweb" ]; then
+    command="killall -s SIGUSR1 bmcweb; sleep 1"
+    desc="BMCWeb current session snapshot data"
+    file_name="/var/persist/home/root/bmcweb_current_session_snapshot.json"
+    if [ -e "$file_name" ]; then
+        add_copy_file "$file_name" "$desc"
+    fi
+fi


### PR DESCRIPTION
1) Send SIGUSR1 signal to bmcweb so that it captures session and persistent data to a file

2) Copy the file to the BMC dump package

Tested:
Thu Apr 28 10:04:28 UTC 2022 INFO: Copied BMCWeb current session snapshot data /var/persist/home/root/bmcweb_current_session_snapshot.json Thu Apr 28 10:04:28 UTC 2022 INFO: Copied BMCWeb current session persistent data /var/persist/home/root/bmcweb_persistent_data.json

root@rain104bmc:/tmp/test/obmcdump_00000000_1651140267# ls -lah bmcweb_current_session_snapshot.json
-rw-r--r--    1 root     root         414 Apr 28 10:04
bmcweb_current_session_snapshot.json
root@rain104bmc:/tmp/test/obmcdump_00000000_1651140267# ls -lah
bmcweb_persistent_data.json
-rw-r-----    1 root     root         646 Apr 28 10:04
bmcweb_persistent_data.json


Change-Id: Id07e7214b32eb6caa47bbe9ef89cc55a3d5744a8