### PR TITLE
gendumpheader: Include both originator details or none in dump header

### DIFF
--- a/tools/dreport.d/ibm.d/gendumpheader
+++ b/tools/dreport.d/ibm.d/gendumpheader
@@ -52,10 +52,11 @@ function add_null() {
 
 # Function to add Originator details to dump header
 function add_originator_details() {
-    if [ -z "$ORIGINATOR_TYPE" ]; then
-        add_null 4
+    if [ -z "$ORIGINATOR_TYPE" ] || [ -z "$ORIGINATOR_ID" ]; then
+        add_null 36
         return
     fi
+
     printf '%s' "$ORIGINATOR_TYPE" >> "$FILE"
     len=${#ORIGINATOR_TYPE}
     nulltoadd=$(( SIZE_4 - len ))
@@ -63,10 +64,6 @@ function add_originator_details() {
         add_null "$nulltoadd"
     fi
 
-    if [ -z "$ORIGINATOR_ID" ]; then
-        add_null 32
-        return
-    fi
     printf '%s' "$ORIGINATOR_ID" >> "$FILE"
     len=${#ORIGINATOR_ID}
     nulltoadd=$(( SIZE_32 - len ))


### PR DESCRIPTION
Issue 1: When both originator_type and originator_id are empty,
         only 4 bytes is being null padded(after 1st if check)
         instead of the reserved 36 bytes that was intended for
         originator details. This is causing missed padding.

Issue 2: Only originator_type could be valid with originator_id empty,
         in which case it is not intended to add either of them,
         instead padding of 36 null Byte is the expected outcome.

Fix: If either of originator_id or originator_type is empty, pad 36B.

Test Results: Verified that BMC Dumps are generated with padding.