### PR TITLE
OpenPOWER: Add custom dump type

### DIFF
--- a/dump-extensions/openpower-dumps/meson.build
+++ b/dump-extensions/openpower-dumps/meson.build
@@ -29,3 +29,4 @@ phosphor_dump_manager_sources += [
         'dump-extensions/openpower-dumps/dump_entry_factory.cpp',
         'dump-extensions/openpower-dumps/openpower_dump_entry.cpp'
     ]
+subdir('yamls')

--- a/dump-extensions/openpower-dumps/yamls/dump_types.yaml
+++ b/dump-extensions/openpower-dumps/yamls/dump_types.yaml
@@ -1,0 +1,3 @@
+- xyz.openbmc_project.Dump.Create.DumpType.FaultData:
+      - faultdata
+      - BMC_DUMP

--- a/dump-extensions/openpower-dumps/yamls/meson.build
+++ b/dump-extensions/openpower-dumps/yamls/meson.build
@@ -1,0 +1,2 @@
+dump_types_yaml_files += {'input': 'dump-extensions/openpower-dumps/yamls/dump_types.yaml',
+         'output': 'dump_types.yaml'}

--- a/meson.build
+++ b/meson.build
@@ -132,11 +132,45 @@ configure_file(configuration : conf_data,
                output : 'config.h'
               )
 
-dump_types_yaml_files = []
+phosphor_dump_manager_sources = [
+        'dump_entry.cpp',
+        'dump_manager.cpp',
+        'dump_manager_bmc.cpp',
+        'dump_manager_main.cpp',
+        'dump_serialize.cpp',
+        'elog_watch.cpp',
+        'watch.cpp',
+        'bmc_dump_entry.cpp',
+        'dump_utils.cpp',
+        'dump_offload.cpp',
+        'dump_manager_faultlog.cpp',
+        'faultlog_dump_entry.cpp'
+    ]
 
+phosphor_dump_manager_dependency = [
+        phosphor_dbus_interfaces_dep,
+        sdbusplus_dep,
+        sdeventplus_dep,
+        phosphor_logging_dep,
+        cereal_dep,
+    ]
+
+phosphor_dump_manager_install = true
+
+phosphor_dump_manager_incdir = []
+
+# To get host transport based interface to take respective host
+# dump actions. It will contain required sources and dependency
+# list for phosphor_dump_manager.
+subdir('host-transport-extensions')
+
+#pick any architecture specific dumps
+
+dump_types_yaml_files = []
+subdir('dump-extensions')
 # Dump types YAML file
 dump_types_yaml_files += {'input': 'example_dump_types.yaml',
-         'output': 'dump_types.yaml'}
+         'output': 'example_dump_types.yaml'}
 
 # Copy and combine YAML files
 concatenate_command = 'cat '
@@ -200,42 +234,9 @@ dump_types_cpp = custom_target(
                     output : 'dump_types.cpp'
                  )
 
-phosphor_dump_manager_sources = [
-        'dump_entry.cpp',
-        'dump_manager.cpp',
-        'dump_manager_bmc.cpp',
-        'dump_manager_main.cpp',
-        'dump_serialize.cpp',
-        'elog_watch.cpp',
-        dump_types_hpp,
-        dump_types_cpp,
-        'watch.cpp',
-        'bmc_dump_entry.cpp',
-        'dump_utils.cpp',
-        'dump_offload.cpp',
-        'dump_manager_faultlog.cpp',
-        'faultlog_dump_entry.cpp'
-    ]
-
-phosphor_dump_manager_dependency = [
-        phosphor_dbus_interfaces_dep,
-        sdbusplus_dep,
-        sdeventplus_dep,
-        phosphor_logging_dep,
-        cereal_dep,
-    ]
-
-phosphor_dump_manager_install = true
-
-phosphor_dump_manager_incdir = []
-
-# To get host transport based interface to take respective host
-# dump actions. It will contain required sources and dependency
-# list for phosphor_dump_manager.
-subdir('host-transport-extensions')
-
-#pick any architecture specific dumps
-subdir('dump-extensions')
+phosphor_dump_manager_sources += [
+                                   dump_types_hpp,
+                                   dump_types_cpp]
 
 phosphor_dump_monitor_sources = [
         dump_types_hpp,


### PR DESCRIPTION
A fault data dump is a special dump that contains the details stored on the BMC about the faulty components in a system.
This commit enables the fault data dump.

Test Results:

```
root@p10bmc:~# busctl --verbose call xyz.openbmc_project.Dump.Manager /xyz/openbmc_project/dump/bmc xyz.openbmc_project.Dump.Create CreateDump a{sv} 1 "xyz.openbmc_project.Dump.Create.CreateParameters.DumpType" s "xyz.openbmc_project.Dump.Create.DumpType.FaultData"
MESSAGE "o" {
        OBJECT_PATH "/xyz/openbmc_project/dump/bmc/entry/26";
};
```
journal:
```
Feb 01 04:56:01 p10bmc phosphor-dump-manager[568]: OriginatorId is not provided
Feb 01 04:56:01 p10bmc phosphor-dump-manager[568]: OriginatorType is not provided. Replacing the string with the default value
Feb 01 04:56:01 p10bmc phosphor-dump-manager[568]: Initiating new BMC dump with type: faultdata path:
Feb 01 04:56:01 p10bmc faultlog[1532]: faultlog app to collect deconfig/guard records details
Feb 01 04:56:03 p10bmc faultlog[1532]: Latest chassis poweron time read is :01/30/2033 16:01:00
Feb 01 04:56:05 p10bmc phosphor-dump-manager[1537]: performing dump compression /tmp/NAGDUMP.1012345.00000026.20330201045601
Feb 01 04:56:05 p10bmc phosphor-dump-manager[1537]: Adding Dump Header :/usr/share/dreport.d/include.d/gendumpheader
Feb 01 04:56:05 p10bmc phosphor-dump-manager[1537]: Tue Feb  1 04:56:05 UTC 2033 Report is available in /var/lib/phosphor-debug-collector/dumps/26
Feb 01 04:56:05 p10bmc phosphor-dump-manager[1520]: Tue Feb 1 04:56:05 UTC 2033 Successfully completed
```
Change-Id: I5e79880bfede74f6e467f095cd993ec2c36577d5