### PR TITLE
Add bmcweb host and session details to BMC dump

### DIFF
--- a/tools/dreport.d/plugins.d/bmcweb
+++ b/tools/dreport.d/plugins.d/bmcweb
@@ -1,0 +1,22 @@
+#!/bin/bash
+#
+# config: 123 20
+# @brief: Get bmcweb session details
+#
+# shellcheck disable=SC1091
+. "$DREPORT_INCLUDE/functions"
+
+# collect data only if bmcweb is present
+if [ -e "/usr/bin/bmcweb" ]; then
+    if killall -s SIGUSR1 bmcweb; then
+        sleep 2
+        desc="BMCWeb current session snapshot data"
+        file_name="/var/persist/home/root/bmcweb_current_session_snapshot.json"
+        if [ -e "$file_name" ]; then
+            add_copy_file "$file_name" "$desc"
+        fi
+        echo "successfully collected bmcweb current session snapshot data"
+    else
+        echo "failed to collect bmcweb current session snapshot data"
+    fi
+fi


### PR DESCRIPTION
Tested:
Triggered BMC dump and verified files
File collected.
 Fri Dec 6 09:29:04 UTC 2024 INFO: Copied BMCWeb current session snapshot data /var/persist/home/root/bmcweb_current_session_snapshot.json
 