### PR TITLE
gendumpheader: Add originator id & type even if either is missing

### DIFF
--- a/tools/dreport.d/ibm.d/gendumpheader
+++ b/tools/dreport.d/ibm.d/gendumpheader
@@ -52,23 +52,26 @@ function add_null() {
 
 # Function to add Originator details to dump header
 function add_originator_details() {
-    if [ -z "$ORIGINATOR_TYPE" ] || [ -z "$ORIGINATOR_ID" ]; then
-        add_null 36
-        return
+    if [ -z "$ORIGINATOR_TYPE" ]; then
+       add_null 4
+    else
+        len=${#ORIGINATOR_TYPE}
+        nulltoadd=$(( SIZE_4 - len ))
+        printf '%s' "$ORIGINATOR_TYPE" >> "$FILE"
+        if [ "$nulltoadd" -gt 0 ]; then
+             add_null "$nulltoadd"
+        fi
     fi
 
-    printf '%s' "$ORIGINATOR_TYPE" >> "$FILE"
-    len=${#ORIGINATOR_TYPE}
-    nulltoadd=$(( SIZE_4 - len ))
-    if [ "$nulltoadd" -ne 0 ]; then
-        add_null "$nulltoadd"
-    fi
-
-    printf '%s' "$ORIGINATOR_ID" >> "$FILE"
-    len=${#ORIGINATOR_ID}
-    nulltoadd=$(( SIZE_32 - len ))
-    if [ "$nulltoadd" -eq 0 ]; then
-        add_null "$nulltoadd"
+    if [ -z "$ORIGINATOR_ID" ]; then
+       add_null 32
+    else
+        len=${#ORIGINATOR_ID}
+        nulltoadd=$(( SIZE_32 - len ))
+        printf '%s' "$ORIGINATOR_ID" >> "$FILE"
+        if [ "$nulltoadd" -gt 0 ]; then
+             add_null "$nulltoadd"
+        fi
     fi
 }
 

--- a/tools/dreport.d/include.d/functions
+++ b/tools/dreport.d/include.d/functions
@@ -232,7 +232,7 @@ function get_originator_details() {
         cut -d' ' -f 2 | cut -d'.' -f 6 | cut -d'"' -f 1)
 
     ORIGINATOR_ID=$(echo "$ORIGINATOR_ID" | \
-        cut -d' ' -f 2 | cut -d'"' -f 1)
+        cut -d ' ' -f 2 | cut -d '"' -f 2)
 
     # This hash map for Originator Type is populated based on
     # the info provided by the OriginatedBy.interface.yaml file under


### PR DESCRIPTION
Issue1: Originator_Id string is not getting extracted properly. Fix to extract Originator_id string correctly.

Issue2: Currently if either of the originator id or type is empty the other is not being included in the dump header. Add either of them even if one is missing.

Test Results:

BMC Dumps initiated from Web-UI

ORIGINATOR_ID EMPTY ORIGINATOR_TYPE = '0'
00000220 ....... |YW30UF15700C0...|
00000230 ....... |................|

ORIGINATOR_ID = 1.2.3.4 ORIGINATOR_TYPE is EMPTY
00000220 ....... |YW30UF15700C....|
00000230 ....... |1.2.3.4.........|

ORIGINATOR_ID = 1.2.3.4 ORIGINATOR_TYPE = '0'
00000220 ....... |YW30UF15700C0...|
00000230 ....... |1.2.3.4.........|

BMC Dump initiated using busctl command

00000220 ....... |YW30UF15700C1...|
00000230 ....... |................|

Verified that Originator details are getting correctly added to Dump header.