### PR TITLE
Add a timer to re-trigger failed core dump requests

### DIFF
--- a/core_manager.cpp
+++ b/core_manager.cpp
@@ -16,6 +16,32 @@ namespace core
 {
 
 using namespace std;
+std::queue<std::vector<std::string>> Manager::coreDumpQueue;
+
+void Manager::processCoreDumpQueue()
+{
+    while (Manager::coreDumpQueue.size() > 0)
+    {
+        if (!Manager::coreDumpQueue.front().empty())
+        {
+            try
+            {
+                createHelper(Manager::coreDumpQueue.front());
+                Manager::coreDumpQueue.pop();
+            }
+            catch (const sdbusplus::exception_t& e)
+            {
+                lg2::error("Failed to create dump: {ERROR}", "ERROR", e);
+                break;
+            }
+        }
+    }
+
+    if (Manager::coreDumpQueue.empty())
+    {
+        coreDumpTimer.setEnabled(false);
+    }
+}
 
 void Manager::watchCallback(const UserMap& fileInfo)
 {
@@ -41,10 +67,8 @@ void Manager::watchCallback(const UserMap& fileInfo)
         }
     }
 
-    if (!files.empty())
-    {
-        createHelper(files);
-    }
+    Manager::coreDumpQueue.push(files);
+    processCoreDumpQueue();
 }
 
 void Manager::createHelper(const vector<string>& files)
@@ -68,7 +92,7 @@ void Manager::createHelper(const vector<string>& files)
     catch (const sdbusplus::exception_t& e)
     {
         lg2::error("Failed to GetObject on Dump.Create: {ERROR}", "ERROR", e);
-        return;
+        throw;
     }
     if (mapperResponse.empty())
     {
@@ -97,7 +121,8 @@ void Manager::createHelper(const vector<string>& files)
     }
     catch (const sdbusplus::exception_t& e)
     {
-        lg2::error("Failed to create dump: {ERROR}", "ERROR", e);
+        coreDumpTimer.setEnabled(true);
+        throw;
     }
 }
 


### PR DESCRIPTION
When Dump manager is unavailable during core dump creation, we miss to create the dump. Adding a timer to re-trigger any failed core dump requests after every 5 minutes to fix this issue.

Test Results:
Feb 07 06:06:12 p10bmc systemd[1]: Started Phosphor Dump core monitor.. Feb 07 06:06:35 p10bmc systemd[1]: Started Process Core Dump (PID 12904
                                   /UID 0).
Feb 07 06:06:36 p10bmc systemd-coredump[12905]: elfutils disabled,
                                   parsing ELF objects not supported
Feb 07 06:06:36 p10bmc systemd-coredump[12905]: [LNK] Process 527
                            (phosphor-dump-m) of user 0 dumped core.
Feb 07 06:06:36 p10bmc systemd[1]: systemd-coredump@1-12904-0.service:
                                   Deactivated successfully.
Feb 07 06:06:36 p10bmc phosphor-dump-monitor[12900]: Failed to create
            dump: sd_bus_call noreply: org.freedesktop.DBus.Error.
            NoReply: Remote peer disconnected
----> core dump failed

----> Retriggered after 5 minutes
Feb 07 06:11:12 p10bmc phosphor-dump-manager[12920]: OriginatorId is
                                                     not provided
Feb 07 06:11:12 p10bmc phosphor-dump-manager[12920]: OriginatorType is
             not provided. Replacing the string with the default value
Feb 07 06:11:12 p10bmc phosphor-dump-manager[12920]: Initiating new BMC
             dump with type: core path: /var/lib/systemd/coredump/
             core.phosphor-dump-m.0.a059fa7b52814a7485a001bfa74ab556.527
             .1738908395000000.zst
Feb 07 06:11:12 p10bmc pvm_dump_offload[10067]: Watch interfaceAdded
             path (/xyz/openbmc_project/dump/bmc/entry/16)
Feb 07 06:11:12 p10bmc openpower-dump-monitor[1428]: Signal received at
              /xyz/openbmc_project/dump/bmc/entry/16:

Change-Id: If4eeeda582e1759809e3d0f81fcc8c8f2775b42e