### PR TITLE
Add entity-manager objects to dump

### DIFF
--- a/.shellcheck-ignore
+++ b/.shellcheck-ignore
@@ -14,6 +14,7 @@ tools/dreport.d/plugins.d/dmesginfo
 tools/dreport.d/plugins.d/elog
 tools/dreport.d/plugins.d/elogall
 tools/dreport.d/plugins.d/emconfig
+tools/dreport.d/plugins.d/emobjects
 tools/dreport.d/plugins.d/failedservices
 tools/dreport.d/plugins.d/fanctldump
 tools/dreport.d/plugins.d/fanmondump

--- a/tools/dreport.d/ibm.d/gendumpheader
+++ b/tools/dreport.d/ibm.d/gendumpheader
@@ -53,24 +53,24 @@ function add_null() {
 # Function to add Originator details to dump header
 function add_originator_details() {
     if [ -z "$ORIGINATOR_TYPE" ]; then
-       add_null 4
+        add_null 4
     else
         len=${#ORIGINATOR_TYPE}
         nulltoadd=$(( SIZE_4 - len ))
         printf '%s' "$ORIGINATOR_TYPE" >> "$FILE"
         if [ "$nulltoadd" -gt 0 ]; then
-             add_null "$nulltoadd"
+            add_null "$nulltoadd"
         fi
     fi
 
     if [ -z "$ORIGINATOR_ID" ]; then
-       add_null 32
+        add_null 32
     else
         len=${#ORIGINATOR_ID}
         nulltoadd=$(( SIZE_32 - len ))
         printf '%s' "$ORIGINATOR_ID" >> "$FILE"
         if [ "$nulltoadd" -gt 0 ]; then
-             add_null "$nulltoadd"
+            add_null "$nulltoadd"
         fi
     fi
 }

--- a/tools/dreport.d/plugins.d/emobjects
+++ b/tools/dreport.d/plugins.d/emobjects
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+#
+# config: 2 20
+# @brief: Dump entity-manager
+#
+
+# shellcheck disable=SC1091
+. "$DREPORT_INCLUDE"/functions
+
+file_name="emobjects.log"
+
+desc="entity manager objects"
+command="busctl call --verbose --no-pager \
+                xyz.openbmc_project.EntityManager \
+                /xyz/openbmc_project/inventory \
+                org.freedesktop.DBus.ObjectManager \
+                GetManagedObjects"
+
+add_cmd_output "$command" "$file_name" "$desc";


### PR DESCRIPTION
Collect entity-manager's D-Bus properties.

Tested:
The file and the data are in the dump:
```
~/BMCDUMP.XXXXXXX.00000000.20250226205426_out/archive$ head emobjects.log
MESSAGE "a{oa{sa{sv}}}" {
        ARRAY "{oa{sa{sv}}}" {
                DICT_ENTRY "oa{sa{sv}}" {
                        OBJECT_PATH "/xyz/openbmc_project/inventory/system/board/Ingraham_Board";
                        ARRAY "{sa{sv}}" {
                                DICT_ENTRY "sa{sv}" {
                                        STRING "org.freedesktop.DBus.Peer";
                                        ARRAY "{sv}" {
                                        };
                                };

```