### PR TITLE
Create offload PEL for system and resource dump

### DIFF
--- a/dump-extensions/openpower-dumps/resource_dump_entry.cpp
+++ b/dump-extensions/openpower-dumps/resource_dump_entry.cpp
@@ -41,6 +41,16 @@ void Entry::initiateOffload(std::string uri)
     }
     phosphor::dump::Entry::initiateOffload(uri);
     phosphor::dump::host::requestOffload(sourceDumpId());
+    auto path = std::filesystem::path(RESOURCE_DUMP_SERIAL_PATH) /
+                std::to_string(id);
+#ifdef LOG_PEL_ON_DUMP_ACTIONS
+    auto bus = sdbusplus::bus::new_default();
+    // Log PEL for dump offload
+    phosphor::dump::createPEL(
+        bus, path, "Resource Dump", id,
+        "xyz.openbmc_project.Logging.Entry.Level.Informational",
+        "xyz.openbmc_project.Dump.Error.Offload");
+#endif
 }
 
 void Entry::update(uint64_t timeStamp, uint64_t dumpSize, uint32_t sourceId)
@@ -112,12 +122,14 @@ void Entry::delete_()
                 .c_str());
     }
 
-    // Log PEL for dump /offload
+#ifdef LOG_PEL_ON_DUMP_ACTIONS
+    // Log PEL for dump
     auto dBus = sdbusplus::bus::new_default();
     phosphor::dump::createPEL(
-        dBus, dumpPathOffLoadUri, "Resource Dump", dumpId,
+        dBus, path, "Resource Dump", dumpId,
         "xyz.openbmc_project.Logging.Entry.Level.Informational",
         "xyz.openbmc_project.Dump.Error.Invalidate");
+#endif
 }
 } // namespace resource
 } // namespace dump

--- a/dump-extensions/openpower-dumps/system_dump_entry.cpp
+++ b/dump-extensions/openpower-dumps/system_dump_entry.cpp
@@ -32,6 +32,16 @@ void Entry::initiateOffload(std::string uri)
             .c_str());
     phosphor::dump::Entry::initiateOffload(uri);
     phosphor::dump::host::requestOffload(sourceDumpId());
+    auto path = std::filesystem::path(SYSTEM_DUMP_SERIAL_PATH) /
+                std::to_string(id);
+#ifdef LOG_PEL_ON_DUMP_ACTIONS
+    auto bus = sdbusplus::bus::new_default();
+    // Log PEL for dump offload
+    phosphor::dump::createPEL(
+        bus, path, "System Dump", id,
+        "xyz.openbmc_project.Logging.Entry.Level.Informational",
+        "xyz.openbmc_project.Dump.Error.Offload");
+#endif
 }
 
 void Entry::update(uint64_t timeStamp, uint64_t dumpSize,
@@ -116,13 +126,14 @@ void Entry::delete_()
                         path.string(), e.what())
                 .c_str());
     }
-
-    // Log PEL for dump delete/offload
+#ifdef LOG_PEL_ON_DUMP_ACTIONS
+    // Log PEL for dump delete
     auto dBus = sdbusplus::bus::new_default();
     phosphor::dump::createPEL(
-        dBus, dumpPathOffLoadUri, "System Dump", dumpId,
+        dBus, path, "System Dump", dumpId,
         "xyz.openbmc_project.Logging.Entry.Level.Informational",
         "xyz.openbmc_project.Dump.Error.Invalidate");
+#endif
 }
 } // namespace system
 } // namespace dump


### PR DESCRIPTION
Create offload PEL for system/resource dumps to allow differentiation between manual dump deletion and dump offload. This functionality is enabled for BMC and BMC stored dumps in earlier commit.

Tested:

```
Mar 28 09:50:28 rain149bmc phosphor-dump-manager[6350]: Sending request to offload dump id(2), eid(9)
Mar 28 09:50:28 rain149bmc phosphor-dump-manager[6350]: Done. PLDM message, id(2 )RC(0)
Mar 28 09:50:28 rain149bmc pldmd[691]: Hit the object path match for /xyz/openbmc_project/dump/system/entry/1
Mar 28 09:50:28 rain149bmc pldmd[691]: DumpHandler::getOffloadUri path = /xyz/openbmc_project/dump/system/entry/1 fileHandle = 2
Mar 28 09:50:28 rain149bmc pldmd[691]: socketInterface=/tmp/DumpOffloadSockets/system_dump_93
Mar 28 09:50:28 rain149bmc phosphor-log-manager[346]: Created PEL 0x5001999b (BMC ID 165) with SRC BD8D6029

Mar 28 09:52:35 rain149bmc phosphor-dump-manager[6350]: Sending request to offload dump id(1090519040), eid(9)
Mar 28 09:52:35 rain149bmc phosphor-dump-manager[6350]: Done. PLDM message, id(1090519040 )RC(0)
Mar 28 09:52:35 rain149bmc pldmd[691]: Hit the object path match for /xyz/openbmc_project/dump/resource/entry/2
Mar 28 09:52:35 rain149bmc pldmd[691]: DumpHandler::getOffloadUri path = /xyz/openbmc_project/dump/resource/entry/2 fileHandle = 1090519040
Mar 28 09:52:35 rain149bmc pldmd[691]: socketInterface=/tmp/DumpOffloadSockets/resource_dump_936
Mar 28 09:52:35 rain149bmc phosphor-log-manager[346]: Created PEL 0x5001999e (BMC ID 168) with SRC BD8D6029
```

Change-Id: I554fc142307b37c110edbb780801186cac985872