### PR TITLE
Create PEL when a dump is offloaded

### DIFF
--- a/bmc_dump_entry.hpp
+++ b/bmc_dump_entry.hpp
@@ -70,7 +70,7 @@ class Entry :
         this->phosphor::dump::bmc::EntryIfaces::emit_object_added();
     }
 
-#ifdef LOG_PEL_ON_DUMP_DELETE
+#ifdef LOG_PEL_ON_DUMP_ACTIONS
     /** @brief Delete the dump and D-Bus object
      */
     void delete_() override

--- a/bmcstored_dump_entry.cpp
+++ b/bmcstored_dump_entry.cpp
@@ -96,6 +96,14 @@ void Entry::initiateOffload(std::string uri)
                 log<level::ERR>(fmt::format("Dump offload completed id({})",
                                             this->getDumpId())
                                     .c_str());
+#ifdef LOG_PEL_ON_DUMP_ACTIONS
+                auto bus = sdbusplus::bus::new_default();
+                // Log PEL for dump offload
+                phosphor::dump::createPEL(
+                    bus, path(), "BMC Stored Dump", id,
+                    "xyz.openbmc_project.Logging.Entry.Level.Informational",
+                    "xyz.openbmc_project.Dump.Error.Offload");
+#endif
             }
             else
             {

--- a/dump-extensions/openpower-dumps/resource_dump_entry.cpp
+++ b/dump-extensions/openpower-dumps/resource_dump_entry.cpp
@@ -41,6 +41,16 @@ void Entry::initiateOffload(std::string uri)
     }
     phosphor::dump::Entry::initiateOffload(uri);
     phosphor::dump::host::requestOffload(sourceDumpId());
+#ifdef LOG_PEL_ON_DUMP_ACTIONS
+    auto bus = sdbusplus::bus::new_default();
+    auto path = std::filesystem::path(RESOURCE_DUMP_SERIAL_PATH) /
+                std::to_string(id);
+    // Log PEL for dump offload
+    phosphor::dump::createPEL(
+        bus, path, "Resource Dump", id,
+        "xyz.openbmc_project.Logging.Entry.Level.Informational",
+        "xyz.openbmc_project.Dump.Error.Offload");
+#endif
 }
 
 void Entry::update(uint64_t timeStamp, uint64_t dumpSize, uint32_t sourceId)
@@ -112,12 +122,14 @@ void Entry::delete_()
                 .c_str());
     }
 
-    // Log PEL for dump /offload
+#ifdef LOG_PEL_ON_DUMP_ACTIONS
+    // Log PEL for dump
     auto dBus = sdbusplus::bus::new_default();
     phosphor::dump::createPEL(
-        dBus, dumpPathOffLoadUri, "Resource Dump", dumpId,
+        dBus, path, "Resource Dump", dumpId,
         "xyz.openbmc_project.Logging.Entry.Level.Informational",
         "xyz.openbmc_project.Dump.Error.Invalidate");
+#endif
 }
 } // namespace resource
 } // namespace dump

--- a/dump-extensions/openpower-dumps/system_dump_entry.cpp
+++ b/dump-extensions/openpower-dumps/system_dump_entry.cpp
@@ -32,6 +32,16 @@ void Entry::initiateOffload(std::string uri)
             .c_str());
     phosphor::dump::Entry::initiateOffload(uri);
     phosphor::dump::host::requestOffload(sourceDumpId());
+    auto path = std::filesystem::path(SYSTEM_DUMP_SERIAL_PATH) /
+                std::to_string(id);
+#ifdef LOG_PEL_ON_DUMP_ACTIONS
+    auto bus = sdbusplus::bus::new_default();
+    // Log PEL for dump offload
+    phosphor::dump::createPEL(
+        bus, path, "System Dump", id,
+        "xyz.openbmc_project.Logging.Entry.Level.Informational",
+        "xyz.openbmc_project.Dump.Error.Offload");
+#endif
 }
 
 void Entry::update(uint64_t timeStamp, uint64_t dumpSize,
@@ -116,13 +126,14 @@ void Entry::delete_()
                         path.string(), e.what())
                 .c_str());
     }
-
-    // Log PEL for dump delete/offload
+#ifdef LOG_PEL_ON_DUMP_ACTIONS
+    // Log PEL for dump delete
     auto dBus = sdbusplus::bus::new_default();
     phosphor::dump::createPEL(
-        dBus, dumpPathOffLoadUri, "System Dump", dumpId,
+        dBus, path, "System Dump", dumpId,
         "xyz.openbmc_project.Logging.Entry.Level.Informational",
         "xyz.openbmc_project.Dump.Error.Invalidate");
+#endif
 }
 } // namespace system
 } // namespace dump

--- a/dump_utils.hpp
+++ b/dump_utils.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "config.h"
+
 #include "dump_manager.hpp"
 
 #include <fmt/core.h>

--- a/meson.build
+++ b/meson.build
@@ -131,7 +131,7 @@ conf_data.set_quoted('FAULTLOG_DUMP_PATH', get_option('FAULTLOG_DUMP_PATH'),
 conf_data.set('BMC_DUMP_ROTATE_CONFIG', get_option('dump_rotate_config').enabled(),
                description : 'Turn on rotate config for bmc dump'
              )
-conf_data.set('LOG_PEL_ON_DUMP_DELETE', get_option('log_pel_on_dump_delete').enabled(),
+conf_data.set('LOG_PEL_ON_DUMP_ACTIONS', get_option('log_pel_on_dump_actions').enabled(),
                description : 'Turn on to log PEL while deleting the dump'
              )
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -85,7 +85,7 @@ option('dump_rotate_config', type: 'feature',
         description : 'Enable rotate config for bmc dump'
       )
 
-option('log_pel_on_dump_delete', type: 'feature',
+option('log_pel_on_dump_actions', type: 'feature',
         value : 'disabled',
         description : 'Log PEL on deleting the dump'
       )


### PR DESCRIPTION
Currently, there is no distinct PEL for dump offload. When a dump is offloaded from the HMC, it is deleted after the offload, and the user only sees a delete PEL. As a result, users cannot distinguish between a manual dump deletion and a dump offload. To address this, creating a separate offload PEL, enabling users to differentiate between manual dump deletions and dump offloads.

Test Results:

```
Apr 03 10:11:40 p10bmc bmcweb[874]: (2025-04-03 10:11:40) [CRITICAL "dump_offload.hpp":405] INFO: bmc Dump id 2 offload initiated by: 10.231.201.31
Apr 03 10:11:40 p10bmc phosphor-dump-manager[469]: offload started id(2) uri(/tmp/DumpOffloadSockets/bmc_dump_592)
Apr 03 10:11:41 p10bmc phosphor-offload-handler[1762]: Opening File for RW, FILENAME(BMCDUMP.139F230.0000002.20250403101010)
Apr 03 10:11:43 p10bmc phosphor-dump-manager[469]: Dump offload completed id(2)
Apr 03 10:11:43 p10bmc phosphor-log-manager[366]: Created PEL 0x5000040b (BMC ID 90) with SRC BD8D6029

Apr 03 10:36:42 p10bmc bmcweb[874]: (2025-04-03 10:36:42) [CRITICAL "dump_offload.hpp":442] INFO:Request open for system dump offload withurl: /redfish/v1/Systems/system/LogServices/Dump/Entries/SBE_30000001/attachment
Apr 03 10:36:42 p10bmc bmcweb[874]: (2025-04-03 10:36:42) [CRITICAL "dump_offload.hpp":496] INFO: sbe dump id 30000001 offload initiated by: 10.231.201.31
Apr 03 10:36:42 p10bmc phosphor-dump-manager[469]: offload started id(30000001) uri(/tmp/DumpOffloadSockets/sbe_dump_630)
Apr 03 10:36:43 p10bmc phosphor-offload-handler[19252]: Opening File for RW, FILENAME(SYSDUMP.139F230.30000001.20250403103304)
Apr 03 10:36:43 p10bmc phosphor-dump-manager[469]: Dump offload completed id(30000001)
Apr 03 10:36:43 p10bmc phosphor-log-manager[366]: Created PEL 0x50000443 (BMC ID 150) with SRC BD8D6029
```

Change-Id: I554fc142307b37c110edbb780801186cac985872