### PR TITLE
1120 rebase: Add bmcweb host & session details to BMCdump

### DIFF
--- a/tools/dreport.d/plugins.d/bmcweb
+++ b/tools/dreport.d/plugins.d/bmcweb
@@ -1,0 +1,22 @@
+#!/bin/bash
+#
+# config: 123 20
+# @brief: Get bmcweb session details
+#
+# shellcheck disable=SC1091
+. "$DREPORT_INCLUDE/functions"
+
+# collect data only if bmcweb is present
+if [ -e "/usr/bin/bmcweb" ]; then
+    if killall -s SIGUSR1 bmcwebd; then
+        sleep 2
+        desc="BMCWeb current session snapshot data"
+        file_name="/var/persist/home/root/bmcweb_current_session_snapshot.json"
+        if [ -e "$file_name" ]; then
+            add_copy_file "$file_name" "$desc"
+        fi
+        echo "successfully collected bmcweb current session snapshot data"
+    else
+        echo "failed to collect bmcweb current session snapshot data"
+    fi
+fi


### PR DESCRIPTION
Tested:
Triggered BMC dump and verified files
File collected.
May 30 10:02:38 p10bmc phosphor-dump-manager[1324]: successfully collected bmcweb current session snapshot data 
/var/persist/home/root/bmcweb_current_session_snapshot.json