### PR TITLE
opdump: Fix dbus object path from Entry to entry

### DIFF
--- a/dump-extensions/openpower-dumps/dump-extensions.cpp
+++ b/dump-extensions/openpower-dumps/dump-extensions.cpp
@@ -38,14 +38,8 @@ void loadExtensions(sdbusplus::bus_t& bus, DumpManagerList& dumpList)
         throw std::runtime_error("Failed to create OpenPOWER dump directory");
     }
 
-    using DumpCreate = sdbusplus::client::xyz::openbmc_project::dump::Create<>;
-    auto opDumpPath =
-        sdbusplus::message::object_path(DumpCreate::namespace_path::value) /
-        DumpCreate::namespace_path::system;
-    auto opDumpEntryPath = opDumpPath / "Entry";
-
     dumpList.push_back(std::make_unique<openpower::dump::Manager>(
-        bus, eventP, opDumpPath.str.c_str(), opDumpEntryPath,
-        openpower::dump::OP_DUMP_PATH));
+        bus, eventP, openpower::dump::OP_DUMP_OBJ_PATH,
+        openpower::dump::OP_BASE_ENTRY_PATH, openpower::dump::OP_DUMP_PATH));
 }
 } // namespace phosphor::dump

--- a/dump-extensions/openpower-dumps/op_dump_consts.hpp
+++ b/dump-extensions/openpower-dumps/op_dump_consts.hpp
@@ -5,6 +5,8 @@ namespace openpower::dump
 {
 constexpr uint32_t INVALID_SOURCE_ID = 0xFFFFFFFF;
 constexpr auto OP_DUMP_PATH = "/var/lib/phosphor-debug-collector/opdump";
+constexpr auto OP_BASE_ENTRY_PATH = "/xyz/openbmc_project/dump/system/entry";
+constexpr auto OP_DUMP_OBJ_PATH = "/xyz/openbmc_project/dump/system";
 
 constexpr uint32_t DUMP_ID_PREFIX_MASK = 0xF0000000;
 constexpr uint32_t DUMP_ID_DUMP_ID_MASK = 0x0FFFFFFF;


### PR DESCRIPTION
dbus object path is using Entry instead of entry, this causes any application watching for entry file path to not get inotify.

Verified:
```
Before:
"Entry" is being used in dump object path

busctl tree xyz.openbmc_project.Dump.Manager
└─ /xyz
  └─ /xyz/openbmc_project
    └─ /xyz/openbmc_project/dump
      ├─ /xyz/openbmc_project/dump/bmc
      ├─ /xyz/openbmc_project/dump/faultlog
      └─ /xyz/openbmc_project/dump/system
        └─ /xyz/openbmc_project/dump/system/Entry
          ├─ /xyz/openbmc_project/dump/system/Entry/20000001

After:
"entry" is being used in dump object path

busctl tree xyz.openbmc_project.Dump.Manager
└─ /xyz
  └─ /xyz/openbmc_project
    └─ /xyz/openbmc_project/dump
      ├─ /xyz/openbmc_project/dump/bmc
      ├─ /xyz/openbmc_project/dump/faultlog
      └─ /xyz/openbmc_project/dump/system
        └─ /xyz/openbmc_project/dump/system/entry
          └─ /xyz/openbmc_project/dump/system/entry/B0000003
```