### PR TITLE
dump header: Add default value to system serialNumber

### DIFF
--- a/tools/dreport.d/ibm.d/gendumpheader
+++ b/tools/dreport.d/ibm.d/gendumpheader
@@ -34,9 +34,7 @@ declare -x modelNo
 modelNo=$(busctl get-property $INVENTORY_MANAGER $INVENTORY_PATH \
     $INVENTORY_ASSET_INT Model | cut -d " " -f 2 | sed "s/^\(\"\)\(.*\)\1\$/\2/g")
 #Variables
-declare -x serialNo
-serialNo=$(busctl get-property $INVENTORY_MANAGER $INVENTORY_PATH \
-    $INVENTORY_ASSET_INT SerialNumber | cut -d " " -f 2 | sed "s/^\(\"\)\(.*\)\1\$/\2/g")
+declare -x serialNo="0000000"
 declare -x dDay
 dDay=$(date -d @"$EPOCHTIME" +'%Y%m%d%H%M%S')
 declare -x bmcSerialNo
@@ -272,6 +270,13 @@ function get_bmc_model_serial_number() {
 
     if [ -z "$bmcSerialNo" ]; then
         bmcSerialNo="000000000000"
+    fi
+
+    serialNo=$(busctl get-property $INVENTORY_MANAGER $INVENTORY_PATH \
+     $INVENTORY_ASSET_INT SerialNumber | cut -d " " -f 2 | sed "s/^\(\"\)\(.*\)\1\$/\2/g")
+
+    if [ -z "$serialNo" ]; then
+        serialNo="0000000"
     fi
 }
 


### PR DESCRIPTION
In the usecase where system serial number is not configured, an empty string is returned causing the serialNumber to be empty. This causes dump header size shrinkage, thereby leading to dump extraction failure by ebmcutil tool which strips beyond the header assuming a fixed header length.

Fix:  When system serial Number is empty, use default value of 7 zeroes

```
Verified:
BEFORE
00000000  46 49 4c 45 20 20 20 20  00 40 00 00 00 00 00 00  |FILE    .@......|
00000010  00 00 00 00 00 01 00 0f  42 4d 43 44 55 4d 50 2e  |........BMCDUMP.|
00000020  2e 30 30 30 30 30 30 30  30 2e 32 30 32 35 30 36  |.00000000.202506|
00000030  31 30 30 38 34 34 33 31  00 53 45 43 54 49 4f 4e  |10084431.SECTION|
00000040  20 00 30 00 00 00 00 00  00 00 00 00 01 00 02 00  | .0.............|
00000050  00 00 00 00 00 00 2e 6f  72 42 4d 43 44 55 4d 50  |.......orBMCDUMP|
00000060  00 00 00 00 00 00 00 00  00 42 4d 43 20 44 55 4d  |.........BMC DUM|
00000070  50 20 25 06 10 08 44 31  00 00 00 00 00 02 10 02  |P %...D1........|
00000080  00 00 00 00 00 00 2e 6f  72 39 30 34 33 2d 4d 52  |.......or9043-MR|
00000090  58 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |X...............|
000000a0  00 00 00 00 00 00 00 00  00 53 65 72 76 65 72 2d  |.........Server-|
000000b0  39 30 34 33 2d 4d 52 58  2d 53 4e 00 00 00 00 00  |9043-MRX-SN.....|
000000c0  00 00 00 00 00 00 00 00  70 00 00 00 00 00 00 00  |........p.......|
000000d0  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
*
00000200  00 00 00 00 00 00 00 00  00 00 00 59 57 33 30 55  |...........YW30U|
00000210  46 31 33 33 30 30 38 00  00 00 00 00 00 00 00 00  |F133008.........|
00000220  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
*
00000250  00 00 00 00 00 00 00 00  00 00 00 01 01 00 10 28  |...............(|

AFTER
00000000  46 49 4c 45 20 20 20 20  00 40 00 00 00 00 00 00  |FILE    .@......|
00000010  00 00 00 00 00 01 00 0f  42 4d 43 44 55 4d 50 2e  |........BMCDUMP.|
00000020  30 30 30 30 30 30 30 2e  30 30 30 30 30 30 30 30  |0000000.00000000|
00000030  2e 32 30 32 35 30 36 31  30 30 39 30 34 34 36 00  |.20250610090446.|
00000040  53 45 43 54 49 4f 4e 20  00 30 00 00 00 00 00 00  |SECTION .0......|
00000050  00 00 00 01 00 02 00 00  00 00 00 00 00 2e c0 46  |...............F|
00000060  42 4d 43 44 55 4d 50 00  00 00 00 00 00 00 00 00  |BMCDUMP.........|
00000070  42 4d 43 20 44 55 4d 50  20 25 06 10 09 04 46 00  |BMC DUMP %....F.|
00000080  00 00 00 00 02 10 02 00  00 00 00 00 00 2e c0 46  |...............F|
00000090  39 30 34 33 2d 4d 52 58  00 00 00 00 00 00 00 00  |9043-MRX........|
000000a0  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
000000b0  53 65 72 76 65 72 2d 39  30 34 33 2d 4d 52 58 2d  |Server-9043-MRX-|
000000c0  53 4e 30 30 30 30 30 30  30 00 00 00 00 00 00 00  |SN0000000.......|
000000d0  30 30 30 30 30 30 30 00  00 00 00 00 00 70 00 00  |0000000......p..|
000000e0  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
*
00000220  59 57 33 30 55 46 31 33  33 30 30 38 00 00 00 00  |YW30UF133008....|
00000230  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
*
00000270  01 01 00 10 28 b5 2f fd  04 58 14 ed 01 7a 99 8d  |....(./..X...z..|
```