### PR TITLE
dreport: Added DataSync plugin

### DIFF
--- a/.shellcheck-ignore
+++ b/.shellcheck-ignore
@@ -29,6 +29,7 @@ tools/dreport.d/plugins.d/meminfo
 tools/dreport.d/plugins.d/obmcconsole
 tools/dreport.d/plugins.d/osrelease
 tools/dreport.d/plugins.d/pldmflightrecorder
+tools/dreport.d/plugins.d/rbmc_data_sync
 tools/dreport.d/plugins.d/timedate
 tools/dreport.d/plugins.d/traceevents
 tools/dreport.d/plugins.d/top

--- a/tools/dreport.d/plugins.d/rbmc_data_sync
+++ b/tools/dreport.d/plugins.d/rbmc_data_sync
@@ -1,0 +1,39 @@
+#!/bin/bash
+#
+# config: 2 22
+# @brief: Collect data-sync related data.
+#
+
+. $DREPORT_INCLUDE/functions
+
+# Delete the user defined file if present,
+# to trigger the data-sync fallback behavior, on receiving SIGUSR1.
+USER_CHECK_WATCHED_PATH="/tmp/data_sync_paths_info.lsv"
+if [ -f "$USER_CHECK_WATCHED_PATH" ]; then
+    rm "$USER_CHECK_WATCHED_PATH"
+fi
+
+APP_NAME="phosphor-rbmc-data-sync-mgr"
+DATA_SYNC_DBUS_DATA_FILE="/var/lib/phosphor-data-sync/persistence/dbus_props.json"
+WATCHED_PATHS_JSON_FILE="/tmp/data_sync_paths_info.json"
+
+PID=$(pgrep -f "$APP_NAME")
+
+if [ -z "$PID" ]; then
+    exit 0
+fi
+
+kill -SIGUSR1 "$PID"
+sleep 1
+
+file_name="data-sync.log"
+
+if [[ -f "$DATA_SYNC_DBUS_DATA_FILE" ]]; then
+    command="echo 'Data Sync DBus data properties:'; cat \"$DATA_SYNC_DBUS_DATA_FILE\"; echo"
+    add_cmd_output "$command" "$file_name" "data-sync related DBus Data"
+fi
+
+if [[ -f "$WATCHED_PATHS_JSON_FILE" ]]; then
+    command="echo 'Actively watched paths:'; cat \"$WATCHED_PATHS_JSON_FILE\"; echo"
+    add_cmd_output "$command" "$file_name" "data-sync related Watched Paths JSON"
+fi


### PR DESCRIPTION
Plugin used for collecting Data sync information.
This requires [data-sync PR](https://github.com/ibm-openbmc/phosphor-data-sync/pull/30) to merge first. 

Tested
- Verified on simics. 
Example journalctl and output file:
```bash
huygens phosphor-rbmc-data-sync-mgr[883]: Received signal: 10
huygens phosphor-rbmc-data-sync-mgr[883]: Unable to open user input /tmp/data_sync_check_watched_paths.txt, logging all watched paths
huygens phosphor-rbmc-data-sync-mgr[883]: Wrote all watched paths to file: /tmp/data_sync_current_watched_paths.json

~/BMCDUMP.SIMP10R.00000000.20250630072813$ cat data-sync.log
Data Sync DBus data properties:
{
    "FullSyncStatus": 2
}
Actively watched paths:
[
    "/var/lib/phosphor-state-manager",
    "/var/lib"
]
```

Signed-off-by: Harsh Agarwal <Harsh.Agarwal@ibm.com>
Change-Id: Ic68947bdf499fa7d79a141ed4c7cce797eebc66a