### PR TITLE
Dump manager changes

### DIFF
--- a/dump-extensions/openpower-dumps/dump_entry_factory.cpp
+++ b/dump-extensions/openpower-dumps/dump_entry_factory.cpp
@@ -85,18 +85,16 @@ std::unique_ptr<phosphor::dump::Entry>
             Reason("Resource dump can be initiated only when the host is up"));
     }
 
-    if (!dumpParams.userChallenge.has_value())
-    {
-        lg2::error("Required parameter user challenge is not provided");
-        util::throwInvalidArgument("USER_CHALLENGE", "ARGUMENT_MISSING");
-    }
-
     std::string vspString =
         (!dumpParams.vspString.has_value()) ? "" : *dumpParams.vspString;
 
     std::string userChallengeString = (!dumpParams.userChallenge.has_value())
                                           ? ""
                                           : *dumpParams.userChallenge;
+
+    std::string acfPath =
+        (!dumpParams.acfPath.has_value()) ? "" : *dumpParams.acfPath;
+
     if (createSysDump)
     {
         return std::make_unique<host::system::Entry>(
@@ -109,8 +107,9 @@ std::unique_ptr<phosphor::dump::Entry>
 
     return std::make_unique<host::resource::Entry>(
         bus, objPath.c_str(), id, timeStamp, 0, INVALID_SOURCE_ID, vspString,
-        userChallengeString, phosphor::dump::OperationStatus::InProgress,
-        dumpParams.originatorId, dumpParams.originatorType, mgr);
+        userChallengeString, acfPath,
+        phosphor::dump::OperationStatus::InProgress, dumpParams.originatorId,
+        dumpParams.originatorType, mgr);
 }
 
 std::unique_ptr<phosphor::dump::Entry>

--- a/dump-extensions/openpower-dumps/host_dump_entry.hpp
+++ b/dump-extensions/openpower-dumps/host_dump_entry.hpp
@@ -141,6 +141,24 @@ class Entry : virtual public phosphor::dump::Entry
     }
 
     /**
+     * @brief Gets the acf path string.
+     * @return The acf path string.
+     */
+    auto getAcfPath() const
+    {
+        return static_cast<const Derived*>(this)->acfPath();
+    }
+
+    /**
+     * @brief Sets the acf path string.
+     * @param[in] acfPath The acf path string to set.
+     */
+    void setAcfPath(const std::string& acfPath)
+    {
+        static_cast<Derived*>(this)->acfPath(acfPath);
+    }
+
+    /**
      * @brief Gets the dump request status.
      * @return The dump request status.
      */

--- a/dump-extensions/openpower-dumps/op_dump_util.cpp
+++ b/dump-extensions/openpower-dumps/op_dump_util.cpp
@@ -184,6 +184,12 @@ openpower::dump::DumpParameters extractDumpParameters(
                 OpCreate::CreateParameters::Password),
             params);
 
+    std::optional<std::string> acfPath =
+        safeExtractParameter<std::string>(
+            OpCreate::convertCreateParametersToString(
+                OpCreate::CreateParameters::ACFPath),
+            params);
+
     std::optional<uint64_t> eid = safeExtractParameter<uint64_t>(
         OpCreate::convertCreateParametersToString(
             OpCreate::CreateParameters::ErrorLogId),
@@ -194,8 +200,8 @@ openpower::dump::DumpParameters extractDumpParameters(
             OpCreate::CreateParameters::FailingUnitId),
         params);
 
-    return {dumpType, vspString,    userChallenge, eid,
-            fid,      originatorId, originatorType};
+    return {dumpType, vspString, userChallenge, acfPath,
+            eid,      fid,       originatorId,  originatorType};
 }
 
 } // namespace openpower::dump::util

--- a/dump-extensions/openpower-dumps/op_dump_util.hpp
+++ b/dump-extensions/openpower-dumps/op_dump_util.hpp
@@ -23,6 +23,7 @@ struct DumpParameters
     OpDumpTypes type;
     std::optional<std::string> vspString;
     std::optional<std::string> userChallenge;
+    std::optional<std::string> acfPath;
     std::optional<uint64_t> eid;
     std::optional<uint64_t> fid;
     std::string originatorId;

--- a/dump-extensions/openpower-dumps/resource_dump_entry.cpp
+++ b/dump-extensions/openpower-dumps/resource_dump_entry.cpp
@@ -8,6 +8,7 @@ namespace openpower::dump::host::resource
 Entry::Entry(sdbusplus::bus_t& bus, const std::string& objPath, uint32_t dumpId,
              uint64_t timeStamp, uint64_t dumpSize, const uint32_t sourceId,
              std::string vspStr, std::string usrChallenge,
+             const std::string& acfPathStr,
              phosphor::dump::OperationStatus status, std::string originatorId,
              phosphor::dump::originatorTypes originatorType,
              phosphor::dump::Manager& parent) :
@@ -22,6 +23,7 @@ Entry::Entry(sdbusplus::bus_t& bus, const std::string& objPath, uint32_t dumpId,
     sourceDumpId(sourceId);
     vspString(vspStr);
     userChallenge(usrChallenge);
+    acfPath(acfPathStr);
     // Emit deferred signal.
     this->openpower::dump::host::resource::EntryIfaces::emit_object_added();
 }
@@ -42,6 +44,7 @@ Entry::Entry(sdbusplus::bus_t& bus, const std::string& objPath, uint32_t dumpId,
     sourceDumpId(sourceId);
     vspString("");
     userChallenge("");
+    acfPath("");
     dumpRequestStatus(sdbusplus::common::com::ibm::dump::entry::Resource::
                           HostResponse::Success);
 

--- a/dump-extensions/openpower-dumps/resource_dump_entry.hpp
+++ b/dump-extensions/openpower-dumps/resource_dump_entry.hpp
@@ -45,6 +45,7 @@ class Entry :
      *  @param[in] vspStr- Input to host to generate the resource dump.
      *  @param[in] usrChallenge - User Challenge needed by host to validate the
      *             request.
+     *  @param[in] acfPathStr - Path of the Access Control File.
      *  @param[in] status - status  of the dump.
      *  @param[in] originatorId - Id of the originator of the dump
      *  @param[in] originatorType - Originator type
@@ -53,7 +54,8 @@ class Entry :
     Entry(sdbusplus::bus_t& bus, const std::string& objPath, uint32_t dumpId,
           uint64_t timeStamp, uint64_t dumpSize, uint32_t sourceId,
           std::string vspStr, std::string usrChallenge,
-          phosphor::dump::OperationStatus status, std::string originatorId,
+          const std::string& acfPathStr, phosphor::dump::OperationStatus status,
+          std::string originatorId,
           phosphor::dump::originatorTypes originatorType,
           phosphor::dump::Manager& parent);
 


### PR DESCRIPTION
1. Dump manager changes for accepting ACF path as an additional argument during resource dump creation.
2. Removed the mandatory check for password in `dump-extensions/openpower-dumps/dump_entry_factory.cpp`.