### PR TITLE
TACF Plugin:pluign to collect TACF results

### DIFF
--- a/tools/dreport.d/plugins.d/acfshellout
+++ b/tools/dreport.d/plugins.d/acfshellout
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+#
+# config: 2 40
+# @brief: Save the acf shell execution results
+#
+
+# shellcheck disable=SC1091
+. "$DREPORT_INCLUDE"/functions
+
+
+desc="AcfShell Result"
+result_path="/tmp/acf/"
+
+if [ -e "$result_path" ]; then
+    add_copy_file "$result_path" "$desc"
+fi


### PR DESCRIPTION
This plugin will be used to collect the TACF shell script results captured in /tmp/acf folder.This should be part of the dump collected after the completion of TACF bmcshell script