### PR TITLE
dreport: Add occ-control data to dump

### DIFF
--- a/tools/dreport.d/plugins.d/occctldump
+++ b/tools/dreport.d/plugins.d/occctldump
@@ -1,0 +1,31 @@
+#!/bin/bash
+#
+# config: 2 20
+# @brief: Get the occ-control data dump
+#
+
+. $DREPORT_INCLUDE/functions
+
+if [ ! -e "/usr/bin/openpower-occ-control" ]; then
+    exit 0
+fi
+
+file_name="/tmp/occ_control_dump.json"
+
+rm -f $file_name
+killall -s SIGUSR1 openpower-occ-control
+
+seconds=0
+while [ ! -e "$file_name" ]; do
+    seconds=$(( seconds + 1 ))
+    if [ $seconds -eq 5 ]; then
+        echo "Timed out waiting for occ-control data dump"
+        exit 0
+    fi
+    sleep 1
+done
+
+desc="occ-control data dump"
+add_copy_file "$file_name" "$desc"
+
+rm -rf "$file_name"


### PR DESCRIPTION
Send USR1 signal to openpower-occ-control app to collect it's dump data as part of a BMC dump.

Tested on Rainier:
OCCs not running:
```
$ cat BMCDUMP.139F210.00000000.20250801210223_out/archive/occ_control_dump.json
{
    "objectCount": "4 OCC objects",
    "occ0": {
        "occState": "NOT ACTIVE"
    },
    "occ1": {
        "occState": "NOT ACTIVE"
    },
    "occ2": {
        "occState": "NOT ACTIVE"
    },
    "occ3": {
        "occState": "NOT ACTIVE"
    }
}
```
OCCs running:
```
$ cat BMCDUMP.139F210.00000000.20250801191023_out/archive/occ_control_dump.json
{
    "objectCount": "4 OCC objects",
    "occ0": {
        "occHwmonPath": "/sys/bus/platform/drivers/occ-hwmon/occ-hwmon.1/hwmon/hwmon13",
        "occRole": "MASTER",
        "occState": "ACTIVE",
        "pollResponse": [
            "0000: 93000F00 030C0100 00000000 00000000",
            "0010: 6F705F70 31315F32 35303432 38610000",
            "0020: 53454E53 4F520501 54454D50 0010081C",
            "0030: C0000004 0025555F C0000005 0025555F",
            "0040: C0000006 0023555F C0000007 0024555F",
            "0050: C0000008 0024555F C0000009 0023555F",
            "0060: C000000A 0023555F C000000B 0024555F",
...
```