### PR TITLE
dreport: Capture sensors in fanctldump

### DIFF
--- a/dump-extensions/openpower-dumps/op_dump_util.cpp
+++ b/dump-extensions/openpower-dumps/op_dump_util.cpp
@@ -184,11 +184,10 @@ openpower::dump::DumpParameters extractDumpParameters(
                 OpCreate::CreateParameters::Password),
             params);
 
-    std::optional<std::string> acfPath =
-        safeExtractParameter<std::string>(
-            OpCreate::convertCreateParametersToString(
-                OpCreate::CreateParameters::ACFPath),
-            params);
+    std::optional<std::string> acfPath = safeExtractParameter<std::string>(
+        OpCreate::convertCreateParametersToString(
+            OpCreate::CreateParameters::ACFPath),
+        params);
 
     std::optional<uint64_t> eid = safeExtractParameter<uint64_t>(
         OpCreate::convertCreateParametersToString(

--- a/tools/dreport.d/plugins.d/fanctldump
+++ b/tools/dreport.d/plugins.d/fanctldump
@@ -18,4 +18,8 @@ if [ -e "/usr/bin/fanctl" ]; then
     add_cmd_output "$command" "$file_name" "$desc"
     rm -f /tmp/fan_control_dump.json
 
+    desc="Sensor Values"
+    file_name="sensor_values.json"
+    command="fanctl sensors"
+    add_cmd_output "$command" "$file_name" "$desc"
 fi


### PR DESCRIPTION
The fanctl tool, installed as part of the phosphor-fan set of fan control applications, can output sensor values.  Include these in a dump if fanctl is installed so that the system's operating conditions can be seen from the time of the dump.

Tested:

The new file is in the dump.  Its size is around 15KB.
```
BMCDUMP.981864Y.00000000.20250722210441_out/archive$ ls -l sensor_values.json
-rw-r--r-- 1 spinler spinler 14995 Jul 22 16:05 sensor_values.json
```

Contents:
```
$ head sensor_values.json
1V1CS_0167_p1_rail_iout:         0.625
1V1CS_0167_p1_rail_pout:         1
1V1CS_0167_p1_rail_temperature:  37
1V1CS_0167_p1_rail_vout:         1.11719
1V1CS_0167_p2_rail_iout:         0.625
1V1CS_0167_p2_rail_pout:         1
1V1CS_0167_p2_rail_temperature:  38
1V1CS_0167_p2_rail_vout:         1.11719
1V1CS_2345_p1_rail_iout:         0.5
1V1CS_2345_p1_rail_pout:         1
```

Change-Id: I89b69c746d3ee8d5e6696c23eea72b5c8bc0d564