### PR TITLE
Add targeted ACF path argument while creating dump.

### DIFF
--- a/dump-extensions/openpower-dumps/dump_entry_factory.cpp
+++ b/dump-extensions/openpower-dumps/dump_entry_factory.cpp
@@ -84,14 +84,15 @@ std::unique_ptr<phosphor::dump::Entry>
             Reason("Resource dump can be initiated only when the host is up"));
     }
 
-    if (!dumpParams.userChallenge.has_value())
-    {
-        lg2::error("Required parameter user challenge is not provided");
-        util::throwInvalidArgument("USER_CHALLENGE", "ARGUMENT_MISSING");
-    }
-
     std::string vspString =
         (!dumpParams.vspString.has_value()) ? "" : *dumpParams.vspString;
+
+    std::string userChallengeString = (!dumpParams.userChallenge.has_value())
+                                          ? ""
+                                          : *dumpParams.userChallenge;
+
+    std::string acfPath =
+        (!dumpParams.acfPath.has_value()) ? "" : *dumpParams.acfPath;
 
     if (createSysDump)
     {
@@ -99,14 +100,14 @@ std::unique_ptr<phosphor::dump::Entry>
             bus, objPath.c_str(), id, timeStamp, 0, INVALID_SOURCE_ID,
             phosphor::dump::OperationStatus::InProgress,
             dumpParams.originatorId, dumpParams.originatorType,
-            system::SystemImpact::NonDisruptive, *dumpParams.userChallenge,
-            mgr);
+            system::SystemImpact::NonDisruptive, userChallengeString, mgr);
     }
 
     return std::make_unique<resource::Entry>(
         bus, objPath.c_str(), id, timeStamp, 0, INVALID_SOURCE_ID, vspString,
-        *dumpParams.userChallenge, phosphor::dump::OperationStatus::InProgress,
-        dumpParams.originatorId, dumpParams.originatorType, mgr);
+        *dumpParams.userChallenge, acfPath,
+        phosphor::dump::OperationStatus::InProgress, dumpParams.originatorId,
+        dumpParams.originatorType, mgr);
 }
 
 std::unique_ptr<phosphor::dump::Entry>

--- a/dump-extensions/openpower-dumps/op_dump_util.cpp
+++ b/dump-extensions/openpower-dumps/op_dump_util.cpp
@@ -181,6 +181,12 @@ openpower::dump::DumpParameters
                 OpCreate::CreateParameters::Password),
             params);
 
+    std::optional<std::string> acfPath =
+        safeExtractParameter<std::string>(
+            OpCreate::convertCreateParametersToString(
+                OpCreate::CreateParameters::ACFPath),
+            params);
+
     std::optional<uint64_t> eid = safeExtractParameter<uint64_t>(
         OpCreate::convertCreateParametersToString(
             OpCreate::CreateParameters::ErrorLogId),
@@ -191,8 +197,8 @@ openpower::dump::DumpParameters
             OpCreate::CreateParameters::FailingUnitId),
         params);
 
-    return {dumpType, vspString,    userChallenge, eid,
-            fid,      originatorId, originatorType};
+    return {dumpType, vspString, userChallenge, acfPath,
+            eid,      fid,       originatorId,  originatorType};
 }
 
 } // namespace openpower::dump::util

--- a/dump-extensions/openpower-dumps/op_dump_util.cpp
+++ b/dump-extensions/openpower-dumps/op_dump_util.cpp
@@ -181,11 +181,10 @@ openpower::dump::DumpParameters
                 OpCreate::CreateParameters::Password),
             params);
 
-    std::optional<std::string> acfPath =
-        safeExtractParameter<std::string>(
-            OpCreate::convertCreateParametersToString(
-                OpCreate::CreateParameters::ACFPath),
-            params);
+    std::optional<std::string> acfPath = safeExtractParameter<std::string>(
+        OpCreate::convertCreateParametersToString(
+            OpCreate::CreateParameters::ACFPath),
+        params);
 
     std::optional<uint64_t> eid = safeExtractParameter<uint64_t>(
         OpCreate::convertCreateParametersToString(

--- a/dump-extensions/openpower-dumps/op_dump_util.hpp
+++ b/dump-extensions/openpower-dumps/op_dump_util.hpp
@@ -23,6 +23,7 @@ struct DumpParameters
     OpDumpTypes type;
     std::optional<std::string> vspString;
     std::optional<std::string> userChallenge;
+    std::optional<std::string> acfPath;
     std::optional<uint64_t> eid;
     std::optional<uint64_t> fid;
     std::string originatorId;

--- a/dump-extensions/openpower-dumps/resource_dump_entry.hpp
+++ b/dump-extensions/openpower-dumps/resource_dump_entry.hpp
@@ -53,7 +53,7 @@ class Entry : virtual public phosphor::dump::Entry, virtual public EntryIfaces
      *  @param[in] vspStr- Input to host to generate the resource dump.
      *  @param[in] usrChallenge - User Challenge needed by host to validate the
      *             request.
-     *  @param[in] acfPathStr - Path of the Access Control File. 
+     *  @param[in] acfPathStr - Path of the Access Control File.
      *  @param[in] status - status  of the dump.
      *  @param[in] originatorId - Id of the originator of the dump
      *  @param[in] originatorType - Originator type

--- a/dump-extensions/openpower-dumps/resource_dump_entry.hpp
+++ b/dump-extensions/openpower-dumps/resource_dump_entry.hpp
@@ -53,6 +53,7 @@ class Entry : virtual public phosphor::dump::Entry, virtual public EntryIfaces
      *  @param[in] vspStr- Input to host to generate the resource dump.
      *  @param[in] usrChallenge - User Challenge needed by host to validate the
      *             request.
+     *  @param[in] acfPathStr - Path of the Access Control File. 
      *  @param[in] status - status  of the dump.
      *  @param[in] originatorId - Id of the originator of the dump
      *  @param[in] originatorType - Originator type
@@ -61,8 +62,9 @@ class Entry : virtual public phosphor::dump::Entry, virtual public EntryIfaces
     Entry(sdbusplus::bus_t& bus, const std::string& objPath, uint32_t dumpId,
           uint64_t timeStamp, uint64_t dumpSize, const uint32_t sourceId,
           std::string vspStr, std::string usrChallenge,
-          phosphor::dump::OperationStatus status, std::string originatorId,
-          originatorTypes originatorType, phosphor::dump::Manager& parent) :
+          const std::string& acfPathStr, phosphor::dump::OperationStatus status,
+          std::string originatorId, originatorTypes originatorType,
+          phosphor::dump::Manager& parent) :
         phosphor::dump::Entry(bus, objPath.c_str(), dumpId, timeStamp, dumpSize,
                               std::string(), status, originatorId,
                               originatorType, parent),
@@ -71,6 +73,7 @@ class Entry : virtual public phosphor::dump::Entry, virtual public EntryIfaces
         sourceDumpId(sourceId);
         vspString(vspStr);
         userChallenge(usrChallenge);
+        acfPath(acfPathStr);
         // Emit deferred signal.
         this->openpower::dump::resource::EntryIfaces::emit_object_added();
     };
@@ -104,6 +107,7 @@ class Entry : virtual public phosphor::dump::Entry, virtual public EntryIfaces
         sourceDumpId(sourceId);
         vspString("");
         userChallenge("");
+        acfPath("");
         dumpRequestStatus(HostResponse::Success);
 
         // Emit deferred signal.

--- a/host-transport-extensions/pldm/common/pldm_utils.cpp
+++ b/host-transport-extensions/pldm/common/pldm_utils.cpp
@@ -44,9 +44,9 @@ void PLDMInstanceManager::initPLDMInstanceIdDb()
     {
         lg2::error("Error calling pldm_instance_db_init_default, rc = {RC}",
                    "RC", rc);
-        elog<NotAllowed>(Reason(
-            "Required host dump action via pldm is not allowed due "
-            "to pldm_open failed"));
+        elog<NotAllowed>(
+            Reason("Required host dump action via pldm is not allowed due "
+                   "to pldm_open failed"));
     }
 }
 
@@ -73,9 +73,9 @@ pldm_instance_id_t getPLDMInstanceID(uint8_t tid)
     if (rc)
     {
         lg2::error("Failed to get instance id, rc = {RC}", "RC", rc);
-        elog<NotAllowed>(Reason(
-            "Failure in communicating with libpldm service, "
-            "service may not be running"));
+        elog<NotAllowed>(
+            Reason("Failure in communicating with libpldm service, "
+                   "service may not be running"));
     }
     lg2::info("Got instanceId: {INSTANCE_ID} from PLDM eid: {EID}",
               "INSTANCE_ID", instanceID, "EID", tid);
@@ -100,9 +100,9 @@ int openPLDM(mctp_eid_t eid)
     if (pldmTransport)
     {
         lg2::error("open: pldmTransport already setup!");
-        elog<NotAllowed>(Reason(
-            "Required host dump action via pldm is not allowed due "
-            "to openPLDM failed"));
+        elog<NotAllowed>(
+            Reason("Required host dump action via pldm is not allowed due "
+                   "to openPLDM failed"));
         return fd;
     }
 
@@ -112,9 +112,9 @@ int openPLDM(mctp_eid_t eid)
         auto e = errno;
         lg2::error("openPLDM failed, errno: {ERRNO}, FD: FD", "ERRNO", e, "FD",
                    fd);
-       elog<NotAllowed>(Reason(
-            "Required host dump action via pldm is not allowed due "
-            "to openPLDM failed"));
+        elog<NotAllowed>(
+            Reason("Required host dump action via pldm is not allowed due "
+                   "to openPLDM failed"));
     }
     return fd;
 }


### PR DESCRIPTION
Code changes have been made in the dump manager to accept a targeted ACF path as an additional argument during resource dump creation.