### PR TITLE
openpower-dumps: Handle invalid dump type during restore

### DIFF
--- a/dump-extensions/openpower-dumps/dump_entry_factory.cpp
+++ b/dump-extensions/openpower-dumps/dump_entry_factory.cpp
@@ -392,8 +392,10 @@ std::unique_ptr<phosphor::dump::Entry>
         case OpDumpTypes::Hardware:
             return std::make_unique<hardware::Entry>(bus, objPath.string(), id,
                                                      mgr);
+        case OpDumpTypes::MemoryBufferSBE:                                   
         case OpDumpTypes::SBE:
             return std::make_unique<sbe::Entry>(bus, objPath.string(), id, mgr);
+
         default:
             throw std::invalid_argument("Unsupported dump type");
     }

--- a/dump-extensions/openpower-dumps/dump_entry_factory.cpp
+++ b/dump-extensions/openpower-dumps/dump_entry_factory.cpp
@@ -392,7 +392,7 @@ std::unique_ptr<phosphor::dump::Entry>
         case OpDumpTypes::Hardware:
             return std::make_unique<hardware::Entry>(bus, objPath.string(), id,
                                                      mgr);
-        case OpDumpTypes::MemoryBufferSBE:                                   
+        case OpDumpTypes::MemoryBufferSBE:
         case OpDumpTypes::SBE:
             return std::make_unique<sbe::Entry>(bus, objPath.string(), id, mgr);
 

--- a/dump-extensions/openpower-dumps/dump_manager_openpower.cpp
+++ b/dump-extensions/openpower-dumps/dump_manager_openpower.cpp
@@ -142,11 +142,28 @@ void Manager::restore()
             lastEntryId = std::max(lastEntryId, entryId);
             auto objPath = std::filesystem::path(baseEntryPath) / idStr;
 
-            // Create a dump entry with default values
-            auto entry = dumpFact.createEntryWithDefaults(id, objPath);
-
-            // Deserialze the entry
-            entry->deserialize(p.path());
+            // Create a dump entry
+            std::unique_ptr<phosphor::dump::Entry> entry;
+            try
+            {
+                entry = dumpFact.createEntryWithDefaults(id, objPath);
+            }
+            catch (const std::invalid_argument& e)
+            {
+                lg2::error(
+                    "Invalid Dump Path, Dump Storage Path : {PATH} , Dump ID : {ID}",
+                    "PATH", objPath, "ID", id);
+                continue;
+            }
+            // Locate the serialized file
+            std::filesystem::path serializedFilePath = p.path() / ".preserve" /
+                                                       "serialized_entry.bin";
+            if (std::filesystem::exists(serializedFilePath))
+            {
+                // Call deserialize to update the entry from the serialized
+                // file
+                entry->deserialize(serializedFilePath);
+            }
 
             // Insert the entry into the entries map
             entries.insert(std::make_pair(id, std::move(entry)));

--- a/dump-extensions/openpower-dumps/dump_manager_openpower.cpp
+++ b/dump-extensions/openpower-dumps/dump_manager_openpower.cpp
@@ -156,8 +156,8 @@ void Manager::restore()
                 continue;
             }
             // Locate the serialized file
-            std::filesystem::path serializedFilePath = p.path() / ".preserve" /
-                                                       "serialized_entry.bin";
+            std::filesystem::path serializedFilePath =
+                p.path() / ".preserve" / "serialized_entry.bin";
             if (std::filesystem::exists(serializedFilePath))
             {
                 // Call deserialize to update the entry from the serialized

--- a/dump-extensions/openpower-dumps/op_dump_util.cpp
+++ b/dump-extensions/openpower-dumps/op_dump_util.cpp
@@ -184,11 +184,10 @@ openpower::dump::DumpParameters extractDumpParameters(
                 OpCreate::CreateParameters::Password),
             params);
 
-    std::optional<std::string> acfPath =
-        safeExtractParameter<std::string>(
-            OpCreate::convertCreateParametersToString(
-                OpCreate::CreateParameters::ACFPath),
-            params);
+    std::optional<std::string> acfPath = safeExtractParameter<std::string>(
+        OpCreate::convertCreateParametersToString(
+            OpCreate::CreateParameters::ACFPath),
+        params);
 
     std::optional<uint64_t> eid = safeExtractParameter<uint64_t>(
         OpCreate::convertCreateParametersToString(


### PR DESCRIPTION
The type MemoryBufferSBE was missing in the dump restore path, which caused the dump manager to crash. Added MemoryBufferSBE and updated the restore path to skip invalid dump types instead of throwing an exception.

```
Test Results:
Oct 16 06:03:43 p10bmc systemd[1]: Starting Phosphor Dump Manager...
Oct 16 06:03:43 p10bmc phosphor-dump-manager[8919]: dump_manager_faultlog restore not implemented
Oct 16 06:03:43 p10bmc phosphor-dump-manager[8919]: Serialization directory: /var/lib/phosphor-debug-collector/opdump/40000001/.preserve/serialized_entry.bin/.preserve doesnt exist, skip deserialization
Oct 16 06:03:43 p10bmc phosphor-dump-manager[8919]: A new dump file found /var/lib/phosphor-debug-collector/opdump/40000001/SYSDUMP.139B0B0.40000001.20251006004050
Oct 16 06:03:43 p10bmc systemd[1]: Started Phosphor Dump Manager.

Oct 16 06:11:17 p10bmc systemd[1]: Starting Phosphor Dump Manager...
Oct 16 06:11:18 p10bmc phosphor-dump-manager[1525]: dump_manager_faultlog restore not implemented
Oct 16 06:11:18 p10bmc phosphor-dump-manager[1525]: Serialization directory: /var/lib/phosphor-debug-collector/opdump/40000001/.preserve/serialized_entry.bin/.preserve doesnt exist, skip deserialization
Oct 16 06:11:18 p10bmc phosphor-dump-manager[1525]: A new dump file found /var/lib/phosphor-debug-collector/opdump/40000001/SYSDUMP.139B0B0.40000001.20251006004050
Oct 16 06:11:18 p10bmc phosphor-dump-manager[1525]: Unknown dump type
Oct 16 06:11:18 p10bmc phosphor-dump-manager[1525]: A new dump file found /var/lib/phosphor-debug-collector/opdump/50000001/SYSDUMP.139B0B0.40000001.20251006004050
Oct 16 06:11:18 p10bmc systemd[1]: Started Phosphor Dump Manager.

```