### PR TITLE
opfunctions: Fix serial number check

### DIFF
--- a/ffdc
+++ b/ffdc
@@ -14,28 +14,28 @@ invalid or unspecified.
 '
 
 declare -a arr=(
-# Commands to be outputted into individual files
-# Format: "File name" "Command"
-      "FW_level.txt"              "cat /etc/os-release"
-      "BMC_OS.txt"                "uname -a"
-      "BMC_uptime.txt"            "uptime"
-      "BMC_disk_usage.txt"        "df -hT"
+    # Commands to be outputted into individual files
+    # Format: "File name" "Command"
+    "FW_level.txt"              "cat /etc/os-release"
+    "BMC_OS.txt"                "uname -a"
+    "BMC_uptime.txt"            "uptime"
+    "BMC_disk_usage.txt"        "df -hT"
 
-      "systemctl_status.txt"      "systemctl status | cat"
-      "failed_services.txt"       "systemctl --failed"
-      "host_console.txt"          "cat /var/log/obmc-console.log"
+    "systemctl_status.txt"      "systemctl status | cat"
+    "failed_services.txt"       "systemctl --failed"
+    "host_console.txt"          "cat /var/log/obmc-console.log"
 
-      "BMC_proc_list.txt"         "top -n 1 -b"
-      "BMC_journalctl.txt"        "journalctl --no-pager"
-      "BMC_dmesg.txt"             "dmesg"
-      "BMC_procinfo.txt"          "cat /proc/cpuinfo"
-      "BMC_meminfo.txt"           "cat /proc/meminfo"
-      "BMC_traceevents.txt"       "cat /sys/kernel/tracing/trace"
+    "BMC_proc_list.txt"         "top -n 1 -b"
+    "BMC_journalctl.txt"        "journalctl --no-pager"
+    "BMC_dmesg.txt"             "dmesg"
+    "BMC_procinfo.txt"          "cat /proc/cpuinfo"
+    "BMC_meminfo.txt"           "cat /proc/meminfo"
+    "BMC_traceevents.txt"       "cat /sys/kernel/tracing/trace"
 
-# Copy all content from these directories into directories in the .tar
-# Format: "Directory name" "Directory to copy"
-      "obmc"                      "/var/lib/obmc/"
-      "core"                      "/var/lib/systemd/coredump"
+    # Copy all content from these directories into directories in the .tar
+    # Format: "Directory name" "Directory to copy"
+    "obmc"                      "/var/lib/obmc/"
+    "core"                      "/var/lib/systemd/coredump"
 )
 
 dir=$"ffdc_$(date +"%Y-%m-%d_%H-%M-%S")"
@@ -43,51 +43,51 @@ dest="/tmp"
 disable_dreport=false
 
 while [[ $# -gt 0 ]]; do
-  key="$1"
-  case $key in
-    -d|--dir)
-      mkdir -p "$2"
-      if [ $? -eq 0 ]; then
-        dest="$2"
-      else
-        echo "Failed to create the destination directory specified."
-        break
-      fi
-      shift 2
-      ;;
-    -D|--disable_dreport)
-      disable_dreport=true
-      shift
-      ;;
-    -h|--help)
-      echo "$help"
-      exit
-      ;;
-    *)
-      echo "Unknown option $1. Display available options with -h or --help"
-      exit
-      ;;
-  esac
+    key="$1"
+    case $key in
+        -d|--dir)
+            mkdir -p "$2"
+            if [ $? -eq 0 ]; then
+                dest="$2"
+            else
+                echo "Failed to create the destination directory specified."
+                break
+            fi
+            shift 2
+            ;;
+        -D|--disable_dreport)
+            disable_dreport=true
+            shift
+            ;;
+        -h|--help)
+            echo "$help"
+            exit
+            ;;
+        *)
+            echo "Unknown option $1. Display available options with -h or --help"
+            exit
+            ;;
+    esac
 done
 
 echo "Using destination directory $dest"
 
 if [ $disable_dreport = false ]; then
-  dreport -d $dest -v
-  exit
+    dreport -d $dest -v
+    exit
 fi
 
 mkdir -p "$dest/$dir"
 
 for ((i=0;i<${#arr[@]};i+=2)); do
-  if [ -d "${arr[i+1]}" ]; then
-    echo "Copying contents of ${arr[i+1]} to directory ./${arr[i]} ..."
-    mkdir "$dest/$dir/${arr[i]}"
-    cp -r ${arr[i+1]}/* $dest/$dir/${arr[i]}
-  else
-    echo "Collecting ${arr[i]}..."
-    ${arr[i+1]} >> "$dest/$dir/${arr[i]}"
-  fi
+    if [ -d "${arr[i+1]}" ]; then
+        echo "Copying contents of ${arr[i+1]} to directory ./${arr[i]} ..."
+        mkdir "$dest/$dir/${arr[i]}"
+        cp -r ${arr[i+1]}/* $dest/$dir/${arr[i]}
+    else
+        echo "Collecting ${arr[i]}..."
+        ${arr[i+1]} >> "$dest/$dir/${arr[i]}"
+    fi
 done
 
 tar -cf "$dest/$dir.tar" -C $dest $dir

--- a/tools/dreport.d/ibm.d/gendumpheader
+++ b/tools/dreport.d/ibm.d/gendumpheader
@@ -274,10 +274,13 @@ function get_bmc_model_serial_number() {
     fi
 
     serialNo=$(busctl get-property $INVENTORY_MANAGER $INVENTORY_PATH \
-     $INVENTORY_ASSET_INT SerialNumber | cut -d " " -f 2 | sed "s/^\(\"\)\(.*\)\1\$/\2/g")
+        $INVENTORY_ASSET_INT SerialNumber | cut -d " " -f 2 | sed "s/^\(\"\)\(.*\)\1\$/\2/g")
 
-    if [ -z "$serialNo" ]; then
+    if [[ -z "$serialNo" || ! $serialNo =~ ^[A-Za-z0-9]+$ ]]; then
         serialNo="0000000"
+    else
+        # Pad to 7 characters with leading zeros
+        serialNo=$(printf "%07s" "$serialNo" | tr ' ' '0')
     fi
 }
 

--- a/tools/dreport.d/openpower.d/opdreport
+++ b/tools/dreport.d/openpower.d/opdreport
@@ -80,8 +80,11 @@ function fetch_serial_number() {
     serialNo=$(busctl get-property $INVENTORY_MANAGER $INVENTORY_PATH \
         $INVENTORY_ASSET_INT SerialNumber | cut -d " " -f 2 | sed "s/^\(\"\)\(.*\)\1\$/\2/g")
 
-    if [ -z "$serialNo" ]; then
+    if [[ -z "$serialNo" || ! $serialNo =~ ^[A-Za-z0-9]+$ ]]; then
         serialNo="0000000"
+    else
+        # Pad to 7 characters with leading zeros
+        serialNo=$(printf "%07s" "$serialNo" | tr ' ' '0')
     fi
 }
 


### PR DESCRIPTION
If the serial number contains invalid characters, the BMC dump filename
 and header may be incorrect, causing extraction errors. Check that
the serial number is an alphanumeric string exactly 7 characters long; if it is not, assign 0000000 as a default value.

Test Results:

```
Before:
Nov 23 01:04:53 p10bmc phosphor-dump-manager[10552]:  serial no ''
Nov 23 01:04:53 p10bmc phosphor-dump-manager[10552]: performing dump compression /tmp/BMCDUMP.''.00000016.20261123010343
Nov 23 01:04:56 p10bmc phosphor-dump-manager[10552]: Adding Dump Header :/usr/share/dreport.d/include.d/gendumpheader
Nov 23 01:05:03 p10bmc phosphor-dump-manager[10552]: Mon Nov 23 01:05:03 UTC 2026 Report is available in /var/lib/phosphor-debug-collector/dumps/16
Nov 23 01:05:03 p10bmc phosphor-dump-manager[504]: Invalid Dump file name, FILENAME: /var/lib/phosphor-debug-collector/dumps/16/BMCDUMP.''.00000016.20261123010343

After:
Nov 23 01:07:25 p10bmc phosphor-dump-manager[11104]: swetha: serial no ''
Nov 23 01:07:25 p10bmc phosphor-dump-manager[11104]: performing dump compression /tmp/BMCDUMP.0000000.00000017.20261123010614
Nov 23 01:07:27 p10bmc phosphor-dump-manager[11104]: Adding Dump Header :/usr/share/dreport.d/include.d/gendumpheader
Nov 23 01:07:35 p10bmc phosphor-dump-manager[11104]: Mon Nov 23 01:07:35 UTC 2026 Report is available in /var/lib/phosphor-debug-collector/dumps/17
Nov 23 01:07:35 p10bmc phosphor-dump-manager[10704]: Mon Nov 23 01:07:35 UTC 2026 Successfully completed
```

Change-Id: I718a7952d1e510c0294858768a1964d469ad6b7c