### PR TITLE
dump policy: Allow selective dumps based on dump policy

### DIFF
--- a/dump-extensions/openpower-dumps/dump_manager_openpower.cpp
+++ b/dump-extensions/openpower-dumps/dump_manager_openpower.cpp
@@ -46,7 +46,9 @@ sdbusplus::message::object_path Manager::createDump(
         using disabled =
             sdbusplus::xyz::openbmc_project::Dump::Create::Error::Disabled;
 
-        if (!util::isOPDumpsEnabled(bus))
+        DumpParameters dumpParams = util::extractDumpParameters(params);
+
+        if (!util::isOPDumpsEnabled(bus, dumpParams.type))
         {
             lg2::error("OpenPower dumps are disabled, skipping");
             elog<disabled>();

--- a/dump-extensions/openpower-dumps/op_dump_util.cpp
+++ b/dump-extensions/openpower-dumps/op_dump_util.cpp
@@ -19,8 +19,13 @@
 namespace openpower::dump::util
 {
 
-bool isOPDumpsEnabled(sdbusplus::bus_t& bus)
+bool isOPDumpsEnabled(sdbusplus::bus_t& bus, OpDumpTypes type)
 {
+    // System and Resource dumps are not dependent on dump policy
+    if ((type == OpDumpTypes::System) || (type == OpDumpTypes::Resource))
+    {
+        return true;
+    }
     // Set isEnabled as true by default. In a field deployment, the system dump
     // feature is usually enabled to facilitate effective debugging in the event
     // of a failure. If due to some error, the settings service couldn't provide

--- a/dump-extensions/openpower-dumps/op_dump_util.hpp
+++ b/dump-extensions/openpower-dumps/op_dump_util.hpp
@@ -36,12 +36,13 @@ namespace util
 /** @brief Check whether OpenPOWER dumps are enabled
  *
  * param[in] bus - D-Bus handle
+ * param[in] type - OpDumpTypes
  *
  * If the settings service is not running then considering as
  * the dumps are enabled.
  * @return true - if dumps are enabled, false - if dumps are not enabled
  */
-bool isOPDumpsEnabled(sdbusplus::bus_t& bus);
+bool isOPDumpsEnabled(sdbusplus::bus_t& bus, OpDumpTypes type);
 
 using BIOSAttrValueType = std::variant<int64_t, std::string>;
 


### PR DESCRIPTION
dump policy (enabled/disabled) can control only hardware, hostboot, sbe dumps.

dump policy shall not have any effect on system and resource dumps.

Test Results:
```

SystemDump has no effect
root@p11bmc:~# obmcutil poweroff
root@p11bmc:~# busctl --verbose call  xyz.openbmc_project.Dump.Manager /xyz/openbmc_project/dump/system xyz.openbmc_project.Dump.Create CreateDump a{sv} 1 "com.ibm.Dump.Create.CreateParameters.DumpType" s "com.ibm.Dump.Create.DumpType.System"
MESSAGE "o" {
        OBJECT_PATH "/xyz/openbmc_project/dump/system/entry/A0000007";
};

SBE Dump is not allowed
root@p11bmc:~# busctl --verbose call  xyz.openbmc_project.Dump.Manager /xyz/openbmc_project/dump/system xyz.openbmc_project.Dump.Create CreateDump a{sv} 3 "com.ibm.Dump.Create.CreateParameters.DumpType" s "com.ibm.Dump.Create.DumpType.SBE" "com.ibm.Dump.Create.CreateParameters.ErrorLogId" t 0xDEADBEEF "com.ibm.Dump.Create.CreateParameters.FailingUnitId" t 1
Call failed: Dump is disabled on this system.
```