### PR TITLE
dump-compression: Use zstd instead of xz in check_size()

### DIFF
--- a/tools/dreport.d/include.d/functions
+++ b/tools/dreport.d/include.d/functions
@@ -101,15 +101,15 @@ function check_size()
     if [ $((size + cur_dump_size)) -gt $dump_size ]; then
         #Exceed the allowed limit,
         #tar and compress the files and check the size
-        tar -Jcf "$name_dir.tar.xz" -C \
-            $(dirname "$name_dir") $(basename "$name_dir")
-        size=$(stat -c%s "$name_dir.tar.xz")
+        tar --zstd -cf "$name_dir.tar.zst" -C \
+            "$(dirname "$name_dir")" "$(basename "$name_dir")"
+        size=$(stat -c%s "$name_dir.tar.zst")
         if [ $size -gt $dump_size ]; then
             #Remove the the specific data from the name_dir and continue
-            rm "$source" "$name_dir.tar.xz"
+            rm "$source" "$name_dir.tar.zst"
             return $RESOURCE_UNAVAILABLE
         else
-            rm "$name_dir.tar.xz"
+            rm "$name_dir.tar.zst"
         fi
     fi
 


### PR DESCRIPTION
Use zstd instead of xz in check_size() as everywhere else we are using zstd.

Test Results:
```
Jan 28 07:05:29 ever8 phosphor-dump-manager[748]: OriginatorId is not provided
Jan 28 07:05:29 ever8 phosphor-dump-manager[748]: OriginatorType is not provided. Replacing the string with the default value
Jan 28 07:05:29 ever8 phosphor-dump-manager[748]: Initiating new BMC dump with type: user path: 
Jan 28 07:05:30 ever8 edbg[1854]: pu        k0:n0:s0:p00       0x00000000
Jan 28 07:05:30 ever8 edbg[1854]: pu        k0:n0:s0:p01       0x00000000
Jan 28 07:05:30 ever8 edbg[1854]: pu        k0:n0:s0:p02       0x00000000
Jan 28 07:05:30 ever8 edbg[1854]: pu        k0:n0:s0:p03       0x00000000
Jan 28 07:05:30 ever8 edbg[1854]: /usr/bin/edbg getcfam pu 283c -pall
Jan 28 07:05:30 ever8 edbg[1857]: pu        k0:n0:s0:p00       0x00200004
Jan 28 07:05:30 ever8 edbg[1857]: pu        k0:n0:s0:p01       0xC0200104
Jan 28 07:05:30 ever8 edbg[1857]: pu        k0:n0:s0:p02       0x02200404
Jan 28 07:05:30 ever8 edbg[1857]: pu        k0:n0:s0:p03       0x00200204
Jan 28 07:05:30 ever8 edbg[1857]: /usr/bin/edbg getcfam pu 1007 -pall
Jan 28 07:05:30 ever8 edbg[1860]: pu        k0:n0:s0:p00       0x00000000
Jan 28 07:05:30 ever8 edbg[1860]: pu        k0:n0:s0:p01       0x00000000
Jan 28 07:05:30 ever8 edbg[1860]: pu        k0:n0:s0:p02       0x00000000
Jan 28 07:05:30 ever8 edbg[1860]: pu        k0:n0:s0:p03       0x00000000
Jan 28 07:05:30 ever8 edbg[1860]: /usr/bin/edbg getcfam pu 2809 -pall
Jan 28 07:05:44 ever8 openpower-occ-control[1421]: collectDumpData()
Jan 28 07:05:46 ever8 phosphor-dump-manager[1919]: successfully collected bmcweb current session snapshot data
Jan 28 07:05:47 ever8 systemd[1]: phosphor-fan-control@0.service: Sent signal SIGUSR1 to main process 556 (phosphor-fan-co) on client request.
Jan 28 07:05:50 ever8 phosphor-dump-manager[1969]: swetha:
Jan 28 07:05:52 ever8 pldmd[1248]: Received SIGUR1(10) Signal interrupt
Jan 28 07:05:52 ever8 pldmd[1248]: Fight recorder policy is disabled
Jan 28 07:05:57 ever8 phosphor-dump-manager[2021]: cat: can't open '/tmp/pldm_flight_recorder': No such file or directory
Jan 28 07:05:57 ever8 stunnel[1956]: LOG6[per-minute]: OCSP: No AIA responder URL
Jan 28 07:05:57 ever8 stunnel[1956]: LOG6[per-minute]: OCSP: No OCSP stapling response to send
Jan 28 07:05:58 ever8 systemd[1]: Starting Time & Date Service...
Jan 28 07:05:58 ever8 systemd[1]: Started Time & Date Service.
Jan 28 07:06:02 ever8 systemd[1]: Starting Hostname Service...
Jan 28 07:06:03 ever8 systemd[1]: Started Hostname Service.
Jan 28 07:06:04 ever8 phosphor-dump-manager[2249]: Fetched SerialNumber : 780854Y
Jan 28 07:06:04 ever8 phosphor-dump-manager[2249]: performing dump compression /tmp/BMCDUMP.780854Y.00000009.20260128070529
Jan 28 07:06:06 ever8 phosphor-dump-manager[2249]: Adding Dump Header :/usr/share/dreport.d/include.d/gendumpheader
Jan 28 07:06:06 ever8 phosphor-dump-manager[2280]: Fetched SerialNumber : 780854Y
Jan 28 07:06:19 ever8 phosphor-dump-manager[2249]: Wed Jan 28 07:06:19 UTC 2026 Report is available in /var/lib/phosphor-debug-collector/dumps/9
Jan 28 07:06:19 ever8 phosphor-dump-manager[1842]: Wed Jan 28 07:06:19 UTC 2026 Successfully completed
Jan 28 07:06:19 ever8 phosphor-dump-manager[748]: User initiated dump completed, resetting flag
```