### PR TITLE
openpower-dumps: Add PEL for opdumps upon delete and offload

### DIFF
--- a/dump-extensions/openpower-dumps/host_dump_entry.hpp
+++ b/dump-extensions/openpower-dumps/host_dump_entry.hpp
@@ -82,6 +82,11 @@ class Entry : virtual public phosphor::dump::Entry
      */
     void deserialize(const std::filesystem::path& dumpPath);
 
+    const char* dumpTypeString() const
+    {
+        return "Host Dump";
+    }
+
   protected:
     void removeSerializedEntry();
     uint32_t transportId;

--- a/dump-extensions/openpower-dumps/host_dump_entry.tpp
+++ b/dump-extensions/openpower-dumps/host_dump_entry.tpp
@@ -36,7 +36,8 @@ void Entry<Derived>::initiateOffload(std::string uri)
     auto bus = sdbusplus::bus::new_default();
     // Log PEL for dump offload
     phosphor::dump::createPELOnDumpActions(
-        bus, file, "Resource Dump", std::format("{:08x}", id),
+        bus, file, static_cast<Derived*>(this)->dumpTypeString(),
+        std::format("{:08x}", id),
         "xyz.openbmc_project.Logging.Entry.Level.Informational",
         "xyz.openbmc_project.Dump.Error.Offload");
 #endif
@@ -83,7 +84,8 @@ void Entry<Derived>::delete_()
     auto bus = sdbusplus::bus::new_default();
     // Log PEL for dump delete
     phosphor::dump::createPELOnDumpActions(
-        bus, file, "Resource Dump", std::format("{:08x}", id),
+        bus, file, static_cast<Derived*>(this)->dumpTypeString(),
+        std::format("{:08x}", id),
         "xyz.openbmc_project.Logging.Entry.Level.Informational",
         "xyz.openbmc_project.Dump.Error.Invalidate");
     phosphor::dump::Entry::delete_();

--- a/dump-extensions/openpower-dumps/op_dump_consts.hpp
+++ b/dump-extensions/openpower-dumps/op_dump_consts.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "config.h"
+
 #include <cstdint>
 namespace openpower::dump
 {

--- a/dump-extensions/openpower-dumps/openpower_dump_entry.cpp
+++ b/dump-extensions/openpower-dumps/openpower_dump_entry.cpp
@@ -1,3 +1,5 @@
+#include "config.h"
+
 #include "openpower_dump_entry.hpp"
 
 #include "dump_manager.hpp"
@@ -20,7 +22,14 @@ void Entry::delete_()
         // Log Error message and continue
         lg2::error("Failed to delete dump file, errormsg: {ERROR}", "ERROR", e);
     }
-
+#ifdef LOG_PEL_ON_DUMP_ACTIONS
+    auto bus = sdbusplus::bus::new_default();
+    // Log PEL for dump delete
+    phosphor::dump::createPELOnDumpActions(
+        bus, file, "Openpower Dump", std::format("{:08x}", id),
+        "xyz.openbmc_project.Logging.Entry.Level.Informational",
+        "xyz.openbmc_project.Dump.Error.Invalidate");
+#endif
     // Remove Dump entry D-bus object
     phosphor::dump::Entry::delete_();
 }
@@ -29,6 +38,14 @@ void Entry::initiateOffload(std::string uri)
 {
     phosphor::dump::offload::requestOffload(file, id, uri);
     offloaded(true);
+#ifdef LOG_PEL_ON_DUMP_ACTIONS
+    auto bus = sdbusplus::bus::new_default();
+    // Log PEL for dump offload
+    phosphor::dump::createPELOnDumpActions(
+        bus, file, "Openpower Dump", std::format("{:08x}", id),
+        "xyz.openbmc_project.Logging.Entry.Level.Informational",
+        "xyz.openbmc_project.Dump.Error.Offload");
+#endif
 }
 
 } // namespace openpower::dump

--- a/dump-extensions/openpower-dumps/openpower_dump_entry.hpp
+++ b/dump-extensions/openpower-dumps/openpower_dump_entry.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "dump_entry.hpp"
+#include "dump_utils.hpp"
 
 #include <com/ibm/Dump/Entry/Hardware/server.hpp>
 #include <com/ibm/Dump/Entry/Hostboot/server.hpp>

--- a/dump-extensions/openpower-dumps/resource_dump_entry.hpp
+++ b/dump-extensions/openpower-dumps/resource_dump_entry.hpp
@@ -95,6 +95,11 @@ class Entry :
         dumpRequestStatus(status);
     }
 
+    const char* dumpTypeString() const
+    {
+        return "Resource Dump";
+    }
+
   private:
     static constexpr auto TRANSPORT_DUMP_TYPE_IDENTIFIER = 9;
 };

--- a/dump-extensions/openpower-dumps/system_dump_entry.hpp
+++ b/dump-extensions/openpower-dumps/system_dump_entry.hpp
@@ -89,6 +89,11 @@ class Entry :
         dumpRequestStatus(status);
     }
 
+    const char* dumpTypeString() const
+    {
+        return "System Dump";
+    }
+
   private:
     static constexpr auto TRANSPORT_DUMP_TYPE_IDENTIFIER = 3;
 };


### PR DESCRIPTION
When openpower dumps are offloaded or deleted, it is expected to create PELs for such dump actions.

In the user data section of PEL, it is expected that Resource Dump shows "Resource Dump",
Openpower Dump (hostboot/hardware) show "Openpower Dump" System Dumps (MPIPL & Non-disruptive dump) show "System Dump"

Test Results:

```
Delete Non-disruptive System Dump  => PEL  BD8D6025 created
"Primary SRC": {
    "Section Version":          "1",
    "Sub-section type":         "1",
    "Created by":               "bmc pldm",
    "SRC Version":              "0x02",
    "SRC Format":               "0x55",
    "Virtual Progress SRC":     "False",
    "I5/OS Service Event Bit":  "False",
    "Hypervisor Dump Initiated":"False",
    "Backplane CCIN":           "2E2F",
    "Terminate FW Error":       "False",
    "Deconfigured":             "False",
    "Guarded":                  "False",
    "Error Details": {
        "Message":              "BMC/System/Resource dump has been deleted"
    "Reference Code":           "BD8D6025",
    "Hex Word 2":               "00000055",
    "Hex Word 3":               "2E2F0010",
    "Hex Word 4":               "A7004730",
    "Hex Word 5":               "00000000",
    "Hex Word 6":               "00000000",
    "Hex Word 7":               "00000000",
    "Hex Word 8":               "00000000",
    "Hex Word 9":               "00000000"
},
    "User Data 1": {
    "Section Version": "1",
    "Sub-section type": "1",
    "Created by": "bmc error logging",
    "Dump ID": "a0000008",
    "Dump Type": "System Dump",
    "File Name": ""
}

Hostboot Dump Offloaded => PEL BD8D6029 created
"Primary SRC": {
    "Section Version":          "1",
    "Sub-section type":         "1",
    "Created by":               "bmc pldm",
    "SRC Version":              "0x02",
    "SRC Format":               "0x55",
    "Virtual Progress SRC":     "False",
    "I5/OS Service Event Bit":  "False",
    "Hypervisor Dump Initiated":"False",
    "Backplane CCIN":           "2E2F",
    "Terminate FW Error":       "False",
    "Deconfigured":             "False",
    "Guarded":                  "False",
    "Error Details": {
        "Message":              "BMC/System/Resource dump has been offloaded"
    },
    "Valid Word Count":         "0x09",
    "Reference Code":           "BD8D6029",
    "Hex Word 2":               "00000055",
    "Hex Word 3":               "2E2F0010",
    "Hex Word 4":               "00000000",
    "Hex Word 5":               "00000000",
    "Hex Word 6":               "00000000",
    "Hex Word 7":               "00000000",
    "Hex Word 8":               "00000000",
    "Hex Word 9":               "00000000"

"User Data 1": {
    "Section Version": "1",
    "Sub-section type": "1",
    "Created by": "bmc error logging",
    "Dump ID": "20000004",
    "Dump Type": "Openpower Dump",
    "File Name": "/var/lib/phosphor-debug-collector/opdump/20000004/SYSDUMP.13BE960.20000004.20260225062331"
}

Hostboot Dump deleted => PEL BD8D6025 created

"Primary SRC": {
    "Section Version":          "1",
    "Sub-section type":         "1",
    "Created by":               "bmc pldm",
    "SRC Version":              "0x02",
    "SRC Format":               "0x55",
    "Virtual Progress SRC":     "False",
    "I5/OS Service Event Bit":  "False",
    "Hypervisor Dump Initiated":"False",
    "Backplane CCIN":           "2E2F",
    "Terminate FW Error":       "False",
    "Deconfigured":             "False",
    "Guarded":                  "False",
    "Error Details": {
        "Message":              "BMC/System/Resource dump has been deleted"
    },
    "Valid Word Count":         "0x09",
    "Reference Code":           "BD8D6025",
    "Hex Word 2":               "00000055",
    "Hex Word 3":               "2E2F0010",
    "Hex Word 4":               "00000000",
    "Hex Word 5":               "00000000",
    "Hex Word 6":               "00000000",
    "Hex Word 7":               "00000000",
    "Hex Word 8":               "00000000",
    "Hex Word 9":               "00000000"
"User Data 1": {
    "Section Version": "1",
    "Sub-section type": "1",
    "Created by": "bmc error logging",
    "Dump ID": "20000004",
    "Dump Type": "Openpower Dump",
    "File Name": "/var/lib/phosphor-debug-collector/opdump/20000004/SYSDUMP.13BE960.20000004.20260225062331"
}

MPIPL Dump Deleted ->  PEL BD8D6025 created
"Primary SRC": {
    "Section Version":          "1",
    "Sub-section type":         "1",
    "Created by":               "bmc pldm",
    "SRC Version":              "0x02",
    "SRC Format":               "0x55",
    "Virtual Progress SRC":     "False",
    "I5/OS Service Event Bit":  "False",
    "Hypervisor Dump Initiated":"False",
    "Backplane CCIN":           "2E2F",
    "Terminate FW Error":       "False",
    "Deconfigured":             "False",
    "Guarded":                  "False",
    "Error Details": {
        "Message":              "BMC/System/Resource dump has been deleted"
    },
    "Valid Word Count":         "0x09",
    "Reference Code":           "BD8D6025",
    "Hex Word 2":               "00000055",
    "Hex Word 3":               "2E2F0010",
    "Hex Word 4":               "AA00E1A9",
    "Hex Word 5":               "00000000",
    "Hex Word 6":               "00000000",
    "Hex Word 7":               "00000000",
    "Hex Word 8":               "00000000",
    "Hex Word 9":               "00000000"
},
"User Data 1": {
    "Section Version": "1",
    "Sub-section type": "1",
    "Created by": "bmc error logging",
    "Dump ID": "a000000a",
    "Dump Type": "System Dump",
    "File Name": ""
}
```