### PR TITLE
dreport: Capture RBMC info in dump

### DIFF
--- a/tools/dreport.d/plugins.d/rbmcdump
+++ b/tools/dreport.d/plugins.d/rbmcdump
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+#
+# config: 2 20
+# @brief: Collect redundant BMC information
+#
+
+# shellcheck disable=SC1091
+. "$DREPORT_INCLUDE"/functions
+
+desc="Redundant BMC information"
+
+if [ -e "/usr/bin/rbmctool" ]; then
+
+    command="/usr/bin/rbmctool -de"
+    file_name="rbmc-status.log"
+
+    add_cmd_output "$command" "$file_name" "$desc"
+
+    dir_name="/var/lib/phosphor-state-manager/redundant-bmc/"
+    if [ -d "$dir_name" ]; then
+        add_copy_file "$dir_name" "$desc"
+    fi
+fi


### PR DESCRIPTION
Capture:
1. 'rbmctool -de' output
2. The contents of /var/lib/phosphor-state-manager/redundant-bmc/.

Will only do so if /usr/bin/rbmctool exists meaning this is a redundant BMC system.

Tested:

```
Mon Mar 23 18:33:05 UTC 2026 INFO: Collected Redundant BMC information
Mon Mar 23 18:33:05 UTC 2026 INFO: Copied Redundant BMC information /var/lib/phosphor-state-manager/redundant-bmc/
```

In dump:
```
$ head rbmc-status.log

Local BMC
-----------------------------
Role:                 Active
BMC Position:         0
Redundancy Enabled:   true
BMC State:            Ready
Failovers Allowed:    true
Failover In Progress: false
FW Version Hash:      368A4D25

$ ls redundant-bmc/
data.json
```

Change-Id: I38d9c9baa8dc7846380b3058ca947ca82f71ae53