### PR TITLE
openpower-dumps: Fix watch descriptor leak for resource and sys dumps

### DIFF
--- a/dump-extensions/openpower-dumps/dump_entry_factory.cpp
+++ b/dump-extensions/openpower-dumps/dump_entry_factory.cpp
@@ -199,7 +199,7 @@ std::unique_ptr<phosphor::dump::Entry> DumpEntryFactory::createEntry(
          (!dumpParams.vspString.has_value() || dumpParams.vspString->empty() ||
           toUpper(*dumpParams.vspString) == "SYSTEM"));
 
-    uint32_t dumpIdPrefix = getDumpIdPrefix(
+    uint32_t dumpIdPrefix = util::getDumpIdPrefix(
         createSystemDump ? OpDumpTypes::System : dumpParams.type);
 
     id |= dumpIdPrefix;
@@ -272,7 +272,7 @@ std::optional<std::unique_ptr<phosphor::dump::Entry>>
 
     for (const auto& entry : entries)
     {
-        if (getDumpTypeFromId(entry.second->getDumpId()) != dumpType)
+        if (util::getDumpTypeFromId(entry.second->getDumpId()) != dumpType)
         {
             continue;
         }
@@ -341,7 +341,7 @@ std::optional<std::unique_ptr<phosphor::dump::Entry>>
         return std::nullopt;
     }
 
-    id |= getDumpIdPrefix(dumpType);
+    id |= util::getDumpIdPrefix(dumpType);
     std::string idStr = std::format("{:08X}", id);
     auto objPath = std::filesystem::path(baseEntryPath) / idStr;
 
@@ -376,7 +376,7 @@ std::unique_ptr<phosphor::dump::Entry>
     DumpEntryFactory::createEntryWithDefaults(
         uint32_t id, const std::filesystem::path& objPath)
 {
-    auto type = getDumpTypeFromId(id);
+    auto type = util::getDumpTypeFromId(id);
 
     switch (type)
     {

--- a/dump-extensions/openpower-dumps/dump_entry_factory.hpp
+++ b/dump-extensions/openpower-dumps/dump_entry_factory.hpp
@@ -136,68 +136,6 @@ class DumpEntryFactory
         const DumpParameters& dumpParams);
 
     /**
-     * @brief Retrieves the dump ID prefix based on the dump type.
-     * @param[in] dumpType Type of the dump (system, resource, etc.).
-     * @return The prefix to be used for the dump ID.
-     */
-    uint32_t getDumpIdPrefix(OpDumpTypes dumpType)
-    {
-        switch (dumpType)
-        {
-            case OpDumpTypes::Hardware:
-                return HARDWARE_DUMP_ID_PREFIX;
-            case OpDumpTypes::Hostboot:
-                return HOSTBOOT_DUMP_ID_PREFIX;
-            case OpDumpTypes::SBE:
-                return SBE_DUMP_ID_PREFIX;
-            case OpDumpTypes::MemoryBufferSBE:
-                return MSBE_DUMP_ID_PREFIX;
-            case OpDumpTypes::System:
-                return SYSTEM_DUMP_ID_PREFIX;
-            case OpDumpTypes::Resource:
-                return RESOURCE_DUMP_ID_PREFIX;
-            default:
-                lg2::error("unsupported {TYPE}", "TYPE", dumpType);
-        }
-        return 0xFF;
-    }
-
-    /**
-     * @brief Determines the dump type based on the ID prefix.
-     *
-     * @param id The dump ID from which to extract the dump type.
-     * @return The dump type as an enumeration value of OpDumpTypes.
-     *         If the prefix does not match any known type,
-     *         it returns OpDumpTypes::System as a default.
-     */
-    OpDumpTypes getDumpTypeFromId(uint32_t id)
-    {
-        using namespace phosphor::logging;
-        // Extract the highest byte as the prefix
-        uint32_t prefix = id & DUMP_ID_PREFIX_MASK;
-
-        switch (prefix)
-        {
-            case HARDWARE_DUMP_ID_PREFIX:
-                return OpDumpTypes::Hardware;
-            case HOSTBOOT_DUMP_ID_PREFIX:
-                return OpDumpTypes::Hostboot;
-            case SBE_DUMP_ID_PREFIX:
-                return OpDumpTypes::SBE;
-            case MSBE_DUMP_ID_PREFIX:
-                return OpDumpTypes::MemoryBufferSBE;
-            case SYSTEM_DUMP_ID_PREFIX:
-                return OpDumpTypes::System;
-            case RESOURCE_DUMP_ID_PREFIX:
-                return OpDumpTypes::Resource;
-            default:
-                lg2::error("Unknown dump type");
-        }
-
-        return OpDumpTypes::System;
-    }
-
-    /**
      * @brief Update or create a new host dump entry.
      *
      * @tparam T The specific type of dump entry, must be derived from

--- a/dump-extensions/openpower-dumps/dump_manager_openpower.cpp
+++ b/dump-extensions/openpower-dumps/dump_manager_openpower.cpp
@@ -5,7 +5,6 @@
 #include "dump_entry_factory.hpp"
 #include "dump_utils.hpp"
 #include "op_dump_consts.hpp"
-#include "op_dump_util.hpp"
 #include "system_dump_entry.hpp"
 
 #include <com/ibm/Dump/Create/common.hpp>

--- a/dump-extensions/openpower-dumps/dump_manager_openpower.hpp
+++ b/dump-extensions/openpower-dumps/dump_manager_openpower.hpp
@@ -76,6 +76,21 @@ class Manager :
                     else if (event == IN_CREATE &&
                              std::filesystem::is_directory(path))
                     {
+                        auto dumpTypeOpt = util::getDumpTypeFromPath(path);
+
+                        if (!dumpTypeOpt)
+                        {
+                            continue;
+                        }
+
+                        auto dumpType = *dumpTypeOpt;
+
+                        if (dumpType == OpDumpTypes::Resource ||
+                            dumpType == OpDumpTypes::System)
+                        {
+                            continue;
+                        }
+
                         auto recursiveWatch = std::make_unique<Watch>(
                             eventLoop, IN_NONBLOCK, IN_CLOSE_WRITE, EPOLLIN,
                             path, [this](const UserMap& recursiveFileInfo) {

--- a/dump-extensions/openpower-dumps/dump_manager_openpower.hpp
+++ b/dump-extensions/openpower-dumps/dump_manager_openpower.hpp
@@ -3,6 +3,7 @@
 #include "dump_manager.hpp"
 #include "dump_utils.hpp"
 #include "op_dump_consts.hpp"
+#include "op_dump_util.hpp"
 #include "watch.hpp"
 
 #include <com/ibm/Dump/Create/common.hpp>

--- a/dump-extensions/openpower-dumps/op_dump_util.cpp
+++ b/dump-extensions/openpower-dumps/op_dump_util.cpp
@@ -2,6 +2,7 @@
 
 #include "dump_manager.hpp"
 #include "dump_utils.hpp"
+#include "op_dump_consts.hpp"
 
 #include <unistd.h>
 
@@ -208,4 +209,54 @@ openpower::dump::DumpParameters extractDumpParameters(
             eid,      fid,       originatorId,  originatorType};
 }
 
+uint32_t getDumpIdPrefix(OpDumpTypes dumpType)
+{
+    switch (dumpType)
+    {
+        case OpDumpTypes::Hardware:
+            return HARDWARE_DUMP_ID_PREFIX;
+        case OpDumpTypes::Hostboot:
+            return HOSTBOOT_DUMP_ID_PREFIX;
+        case OpDumpTypes::SBE:
+            return SBE_DUMP_ID_PREFIX;
+        case OpDumpTypes::MemoryBufferSBE:
+            return MSBE_DUMP_ID_PREFIX;
+        case OpDumpTypes::System:
+            return SYSTEM_DUMP_ID_PREFIX;
+        case OpDumpTypes::Resource:
+            return RESOURCE_DUMP_ID_PREFIX;
+        default:
+            lg2::error("unsupported {TYPE}", "TYPE", dumpType);
+    }
+    return 0xFF;
+}
+
+OpDumpTypes getDumpTypeFromId(uint32_t id)
+{
+    using namespace phosphor::logging;
+    // Extract the highest byte as the prefix
+    uint32_t prefix = id & DUMP_ID_PREFIX_MASK;
+
+    switch (prefix)
+    {
+        case HARDWARE_DUMP_ID_PREFIX:
+            return OpDumpTypes::Hardware;
+        case HOSTBOOT_DUMP_ID_PREFIX:
+            return OpDumpTypes::Hostboot;
+        case SBE_DUMP_ID_PREFIX:
+            return OpDumpTypes::SBE;
+        case MSBE_DUMP_ID_PREFIX:
+            return OpDumpTypes::MemoryBufferSBE;
+        case SYSTEM_DUMP_ID_PREFIX:
+            return OpDumpTypes::System;
+        case RESOURCE_DUMP_ID_PREFIX:
+            return OpDumpTypes::Resource;
+        default:
+            lg2::error("Unknown dump type");
+    }
+
+    return OpDumpTypes::System;
+}
+
+}
 } // namespace openpower::dump::util

--- a/dump-extensions/openpower-dumps/op_dump_util.cpp
+++ b/dump-extensions/openpower-dumps/op_dump_util.cpp
@@ -258,5 +258,34 @@ OpDumpTypes getDumpTypeFromId(uint32_t id)
     return OpDumpTypes::System;
 }
 
+std::optional<OpDumpTypes> getDumpTypeFromPath(
+    const std::filesystem::path& path)
+{
+    // Extract directory name (expected to be dump ID in hex)
+    const auto idStr = path.filename().string();
+
+    // Validate non-empty and hex
+    if (idStr.empty() ||
+        !std::all_of(idStr.begin(), idStr.end(),
+                     [](unsigned char c) { return std::isxdigit(c); }))
+    {
+        return std::nullopt;
+    }
+
+    try
+    {
+        // Convert hex string to uint32_t
+        uint32_t dumpId = static_cast<uint32_t>(std::stoul(idStr, nullptr, 16));
+
+        return getDumpTypeFromId(dumpId);
+    }
+    catch (const std::exception& e)
+    {
+        // Conversion failed
+        lg2::error("Invalid dump ID in path: {PATH}, error: {ERROR}", "PATH",
+                   path.string(), "ERROR", e.what());
+        return std::nullopt;
+    }
 }
+
 } // namespace openpower::dump::util

--- a/dump-extensions/openpower-dumps/op_dump_util.hpp
+++ b/dump-extensions/openpower-dumps/op_dump_util.hpp
@@ -110,5 +110,21 @@ inline void throwInvalidArgument(const std::string& argumentName,
                           Argument::ARGUMENT_VALUE(errorDetail.c_str()));
 }
 
+/**
+ * @brief Retrieves the dump ID prefix based on the dump type.
+ * @param[in] dumpType Type of the dump (system, resource, etc.).
+ * @return The prefix to be used for the dump ID.
+ */
+uint32_t getDumpIdPrefix(OpDumpTypes dumpType);
+/**
+ * @brief Determines the dump type based on the ID prefix.
+ *
+ * @param id The dump ID from which to extract the dump type.
+ * @return The dump type as an enumeration value of OpDumpTypes.
+ *         If the prefix does not match any known type,
+ *         it returns OpDumpTypes::System as a default.
+ */
+OpDumpTypes getDumpTypeFromId(uint32_t id);
+
 } // namespace util
 } // namespace openpower::dump

--- a/dump-extensions/openpower-dumps/op_dump_util.hpp
+++ b/dump-extensions/openpower-dumps/op_dump_util.hpp
@@ -126,5 +126,14 @@ uint32_t getDumpIdPrefix(OpDumpTypes dumpType);
  */
 OpDumpTypes getDumpTypeFromId(uint32_t id);
 
+/**
+ * @brief Get dump type from path.
+ * @param[in] path Filesystem path containing the dump ID as filename.
+ * @return std::optional<OpDumpTypes> Dump type if valid; std::nullopt
+ * otherwise.
+ */
+std::optional<OpDumpTypes> getDumpTypeFromPath(
+    const std::filesystem::path& path);
+
 } // namespace util
 } // namespace openpower::dump


### PR DESCRIPTION
Issue:
Currently in the opdump path, if any dump directory is created during dump creation, it adds a watch descriptor to monitor for file close event in that directory. While this works for host dumps, resource and system dumps which are never captured in bmc local file system, which will cause a watch descriptor leak as there will never be a file close event for these dumps as they exist on host.

Fix:
Skip adding a watch descriptor for system dump path

Verified:
```
System dump
pldmd[1088]: File name in sendNewFileAvailableCmd that we encode new_file_req is A0000008
pldmd[1088]: resource dump request dir path is /var/lib/pldm/resourcedump/A0000008
phosphor-dump-manager[695]: Dump Notify: Updating dumpId: A0000008 with source Id: 1000000A Size: 3358821488
phosphor-dump-manager[695]: Skipping watch creation for dump: /var/lib/phosphor-debug-collector/opdump/A0000008
```

Change-Id: Ic0cef6073107c97fbe928101366395f4ef7bcc0d