### PR TITLE
dreport: Fix typo in redundantosrelease plugin

### DIFF
--- a/tools/dreport.d/plugins.d/redundantosrelease
+++ b/tools/dreport.d/plugins.d/redundantosrelease
@@ -16,7 +16,7 @@ if [ -z "$REDUNDANT_FW_VERSION" ]; then
 fi
 
 if [ -n "$REDUNDANT_FW_VERSION" ]; then
-    command="printf \"\nREDUNDANT_FW_VERSION=%s\n\" \"\$nREDUNDANT_FW_VERSION\""
+    command="printf \"\nREDUNDANT_FW_VERSION=%s\n\" \"\$REDUNDANT_FW_VERSION\""
     add_cmd_output "$command" "$file_name" "$desc"
 else
     log_warning "No redundant FW available"


### PR DESCRIPTION
Fixed typo in redundantosrelease script where variable name was incorrectly written as "$nREDUNDANT_FW_VERSION" instead of "$REDUNDANT_FW_VERSION" on line 19. This was preventing the redundant firmware version from being properly written to the dump file.

Tested: Verified redundant-os-release file now correctly contains REDUNDANT_FW_VERSION="fw1120.00-1.98-1120.2614.20260406a (RB1120_152)"


Change-Id: I509b4bab219ebac7f32a9235496c7a26233c3de9