### PR TITLE
dreport: Fix bash error related to Priority prop

### DIFF
--- a/tools/dreport.d/include.d/functions
+++ b/tools/dreport.d/include.d/functions
@@ -211,14 +211,14 @@ function populate_redundant_os_n_min_fw_info()
     dbus_command="$dbus_property_command $dbus_object $firmware1 \
         $dbus_object_priority_method $dbus_object_priority"
 
-    firmware1_priority=$(eval "$dbus_command" | cut -d' ' -f 2)
+    firmware1_priority=$(eval "$dbus_command" 2>/dev/null | cut -d' ' -f 2)
 
     # If FW1 is the redundant one then get the redundant info from FW1
     # and get the min FW version info from FW2 or vice-versa
     firmware_primary=""
     firmware_secondary=""
 
-    if [ 1 -eq  "$firmware1_priority" ]; then
+    if [ -n "$firmware1_priority" ] && [ 1 -eq  "$firmware1_priority" ]; then
         firmware_primary="$firmware2"
         firmware_secondary="$firmware1"
     else


### PR DESCRIPTION
When busctl fails to retrieve the Priority property, the firmware1_priority variable becomes empty. This leads to a bash error at line 221:[: : integer expression expected

The issue occurs because the script attempts an integer comparison on an empty value when the RedundancyPriority interface or its Priority property is not yet available.

This situation is commonly observed during firmware/software update, when the D-Bus object is temporarily incomplete and the Priority property has not been initialized yet.

Fix by:

Suppressing stderr from failed busctl calls using 2>/dev/null Adding an explicit empty-string check before performing integer comparison

With this change, the script gracefully handles missing Priority values and defaults to firmware1 as primary when the priority cannot be determined.


Change-Id: I74174a1f035118e85d1299fbd2ce3502f768d622