### PR TITLE
1210: dreport: Check D-Bus name before sending signal

### DIFF
--- a/tools/dreport.d/plugins.d/pldmflightrecorder
+++ b/tools/dreport.d/plugins.d/pldmflightrecorder
@@ -8,8 +8,9 @@
 
 desc="pldm flight recorder"
 
-# collect data only if pldmd is enabled
-if [ -e "/usr/bin/pldmd" ]; then
+# collect data only if pldmd is enabled and has claimed its D-Bus name
+# Checking D-Bus name ensures pldmd is fully initialized and has registered signal handlers
+if [ -e "/usr/bin/pldmd" ] && busctl status xyz.openbmc_project.PLDM > /dev/null 2>&1; then
     command="rm -rf /tmp/pldm_flight_recorder; killall -s SIGUSR1 pldmd; \
            sleep 5; cat /tmp/pldm_flight_recorder"
 
@@ -19,5 +20,5 @@ if [ -e "/usr/bin/pldmd" ]; then
 
     rm -rf /tmp/pldm_flight_recorder
 else
-    log_warning "skipping pldm flight recorder:  pldmd is not enabled"
+    log_warning "skipping pldm flight recorder: pldmd is not enabled or not ready"
 fi


### PR DESCRIPTION
#### dreport: Check D-Bus name before sending signal
```
The pldmflightrecorder plugin sends SIGUSR1 to pldmd to trigger
flight recorder dump. However, if the signal is sent before pldmd
has registered its signal handler, it causes pldmd to crash with
the default signal behavior (process termination).

Add a check to verify that pldmd has claimed its D-Bus name
(xyz.openbmc_project.PLDM) before sending the signal. This ensures
pldmd is fully initialized and has registered signal handlers.

Change-Id: I9e9da70ac6bf4ee1353421da2ab4516547eb3f36
Signed-off-by: Manojkiran Eda <manojkiran.eda@gmail.com>
```