### PR TITLE
PHAL: Support for SBE boot failure dump

### DIFF
--- a/dump-extensions/openpower-dumps/dump_entry_factory.cpp
+++ b/dump-extensions/openpower-dumps/dump_entry_factory.cpp
@@ -181,7 +181,8 @@ std::unique_ptr<phosphor::dump::Entry> DumpEntryFactory::createSBEDumpEntry(
     return std::make_unique<sbe::Entry>(
         bus, objPath.c_str(), id, timeStamp, 0, std::string(),
         phosphor::dump::OperationStatus::InProgress, dumpParams.originatorId,
-        dumpParams.originatorType, dump_eid, dump_fid, mgr);
+        dumpParams.originatorType, dump_eid, dump_fid, mgr,
+        dumpParams.dumpFilesPath, dumpParams.sbeDumpTriggerType);
 }
 
 std::unique_ptr<phosphor::dump::Entry> DumpEntryFactory::createEntry(

--- a/dump-extensions/openpower-dumps/op_dump_util.cpp
+++ b/dump-extensions/openpower-dumps/op_dump_util.cpp
@@ -204,8 +204,24 @@ openpower::dump::DumpParameters extractDumpParameters(
             OpCreate::CreateParameters::FailingUnitId),
         params);
 
-    return {dumpType, vspString, userChallenge, acfPath,
-            eid,      fid,       originatorId,  originatorType};
+    // Extract new SBE boot-failure dump parameters
+    std::optional<std::string> dumpFilesPath =
+        safeExtractParameter<std::string>(
+            OpCreate::convertCreateParametersToString(
+                OpCreate::CreateParameters::DumpFilesPath),
+            params);
+
+    std::optional<std::string> sbeDumpTriggerType =
+        safeExtractParameter<std::string>(
+            OpCreate::convertCreateParametersToString(
+                OpCreate::CreateParameters::SBEDumpTriggerType),
+            params);
+
+    return {dumpType,      vspString,
+            userChallenge, acfPath,
+            eid,           fid,
+            originatorId,  originatorType,
+            dumpFilesPath, sbeDumpTriggerType};
 }
 
 } // namespace openpower::dump::util

--- a/dump-extensions/openpower-dumps/op_dump_util.hpp
+++ b/dump-extensions/openpower-dumps/op_dump_util.hpp
@@ -28,6 +28,11 @@ struct DumpParameters
     std::optional<uint64_t> fid;
     std::string originatorId;
     phosphor::dump::originatorTypes originatorType;
+    // New fields for SBE boot-failure dumps
+    std::optional<std::string>
+        dumpFilesPath;      // Path to pre-collected dump files
+    std::optional<std::string>
+        sbeDumpTriggerType; // BootFailure, Timeout, Downstream)
 };
 
 namespace util

--- a/dump-extensions/openpower-dumps/openpower_dump_entry.hpp
+++ b/dump-extensions/openpower-dumps/openpower_dump_entry.hpp
@@ -3,6 +3,8 @@
 #include "dump_entry.hpp"
 #include "dump_utils.hpp"
 
+#include <com/ibm/Dump/Create/common.hpp>
+#include <com/ibm/Dump/Create/server.hpp>
 #include <com/ibm/Dump/Entry/Hardware/server.hpp>
 #include <com/ibm/Dump/Entry/Hostboot/server.hpp>
 #include <com/ibm/Dump/Entry/SBE/server.hpp>
@@ -284,13 +286,17 @@ class Entry : public virtual openpower::dump::Entry, public virtual SBEIntf
      *  @param[in] failingUnit - Identifier of the failing unit associated with
      *  the dump.
      *  @param[in] parent - Reference to the managing dump manager.
+     *  @param[in] dumpFilesPath - Optional path to pre-collected dump files.
+     *  @param[in] sbeDumpTriggerType - Optional SBE dump trigger type.
      */
     Entry(sdbusplus::bus_t& bus, const std::string& objPath, uint32_t dumpId,
           uint64_t timeStamp, uint64_t fileSize,
           const std::filesystem::path& file,
           phosphor::dump::OperationStatus status, std::string originatorId,
           originatorTypes originatorType, uint64_t eid, uint64_t failingUnit,
-          phosphor::dump::Manager& parent) :
+          phosphor::dump::Manager& parent,
+          const std::optional<std::string>& dumpFilesPath = std::nullopt,
+          const std::optional<std::string>& sbeDumpTriggerType = std::nullopt) :
         phosphor::dump::Entry(bus, objPath.c_str(), dumpId, timeStamp, fileSize,
                               file, status, originatorId, originatorType,
                               parent),
@@ -301,6 +307,20 @@ class Entry : public virtual openpower::dump::Entry, public virtual SBEIntf
     {
         errorLogId(eid);
         failingUnitId(failingUnit);
+
+        // Set new SBE dump properties if provided
+        if (dumpFilesPath.has_value())
+        {
+            this->dumpFilesPath(dumpFilesPath.value());
+        }
+        if (sbeDumpTriggerType.has_value())
+        {
+            // Convert string to enum and set
+            auto triggerType = sdbusplus::com::ibm::Dump::server::Create::
+                convertSBEDumpTriggerTypeFromString(sbeDumpTriggerType.value());
+            this->sbeDumpTriggerType(triggerType);
+        }
+
         this->openpower::dump::sbe::SBEIntf::emit_object_added();
     }
 


### PR DESCRIPTION
When SPPE check for ready fails, sppe_dump hardware procedure is run and this collects SPPE dump data. This change is to package those as an SBE dump.

JIRA:PFEBMC-4444

Change-Id: Ia55c854bd6f72a4b01c44acff5d9791170be72a2