### PR TITLE
dreport: Capture RBMC CFAMS regs in dump

### DIFF
--- a/tools/dreport.d/plugins.d/rbmccfamsdump
+++ b/tools/dreport.d/plugins.d/rbmccfamsdump
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+#
+# config: 2 20
+# @brief: Collect redundant BMC CFAM register information
+#
+
+# shellcheck disable=SC1091
+. "$DREPORT_INCLUDE"/functions
+
+desc="Redundant BMC CFAM register information"
+
+if [ -e "/usr/bin/cfamstool" ]; then
+
+    file_name="rbmc-cfams.log"
+
+    add_cmd_output "cfamstool -d" "$file_name" "$desc"
+    add_cmd_output "echo $'\n'" "$file_name" "$desc"
+    add_cmd_output "cfamstool -r" "$file_name" "$desc"
+fi


### PR DESCRIPTION
Capture the CFAMS registers used for redundant BMC communication using cfamstool, both the parsed and raw versions.

Will only do so if /usr/bin/cfamstool exists, meaning this is a redundant BMC system.

Tested:

In dump:
```
$ cat rbmc-cfams.log
Local BMC CFAM-S scratchpad fields
API Version                0x1
Role                       xyz.openbmc_project.State.BMC.Redundancy.Role.Active
Redundancy Enabled         true
Failovers Allowed          true
Paired                     true
BMC State                  xyz.openbmc_project.State.BMC.BMCState.Ready
Sibling Communication OK   true
Failover Imminent          false
Failover In Progress       false
Not Redundancy Capable     false
In Code Update             false
Heartbeat                  0x71
Failover Requested         false
Failover Requester         xyz.openbmc_project.Control.Failover.Requester.Host
FO w/ PassiveProcProblem   false
FO w/ PassiveBMCProblem    false
FW Version                 0xd3a6e6bc

Sibling BMC CFAM-S scratchpad fields
API Version                0x1
Role                       xyz.openbmc_project.State.BMC.Redundancy.Role.Passive
Redundancy Enabled         true
Failovers Allowed          true
Paired                     true
BMC State                  xyz.openbmc_project.State.BMC.BMCState.Ready
Sibling Communication OK   true
Failover Imminent          false
Failover In Progress       false
Not Redundancy Capable     false
In Code Update             false
Heartbeat                  0x70
Failover Requested         false
Failover Requester         xyz.openbmc_project.Control.Failover.Requester.Host
FO w/ PassiveProcProblem   false
FO w/ PassiveBMCProblem    false
FW Version                 0xd3a6e6bc

Local BMC CFAM-S raw scratchpad registers
0: 0x01788072
1: 0xd3a6e6bc
2: 0x00000000
3: 0x00000000

Sibling BMC CFAM-S raw scratchpad registers
0: 0x01b88070
1: 0xd3a6e6bc
2: 0x00000000
3: 0x00000000
```

Change-Id: I811c8bd6ba59eba74b278286738edb2f656941e0